### PR TITLE
Versioned Apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "clap_complete",
  "cml-chain",
  "cml-core",
+ "getrandom 0.2.17",
  "hex",
  "hex-literal 1.1.0",
  "ic-agent",
@@ -2334,6 +2335,7 @@ dependencies = [
  "redis-macros",
  "reqwest 0.13.3",
  "rslock",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -2356,6 +2358,7 @@ dependencies = [
  "anyhow",
  "charms-data",
  "rand 0.10.1",
+ "secp256k1 0.29.1",
  "sha2 0.10.9",
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,11 @@ clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = { version = "4.6.5", features = ["unstable-dynamic"] }
 cml-chain = { workspace = true }
 cml-core = { workspace = true }
+getrandom = { version = "0.2" }
 hex = { workspace = true }
 hex-literal = { version = "1.1.0" }
 ic-agent = { version = "0.47" }
+secp256k1 = { version = "0.29", features = ["std"] }
 pallas-addresses = { workspace = true }
 pallas-codec = { workspace = true }
 pallas-crypto = { workspace = true }

--- a/charms-app-runner/Cargo.toml
+++ b/charms-app-runner/Cargo.toml
@@ -15,5 +15,6 @@ homepage.workspace = true
 anyhow = { workspace = true }
 charms-data = { path = "../charms-data", version = "15.0.0" }
 rand = { version = "0.10.1" }
+secp256k1 = { version = "0.29", default-features = false, features = ["std"] }
 sha2 = { workspace = true }
 wasmi = { version = "1.0.9", default-features = false, features = ["std", "prefer-btree-collections"] }

--- a/charms-app-runner/src/lib.rs
+++ b/charms-app-runner/src/lib.rs
@@ -372,10 +372,10 @@ impl AppRunner {
 
         if let Some(versioned_app) = versioned_apps.get(&app.vk) {
             let version_func = instance
-                .get_func(&store, "__charms_version")
+                .get_func(&store, "__app_version")
                 .ok_or_else(|| {
                     anyhow::anyhow!(
-                        "versioned app {} does not export `__charms_version`",
+                        "versioned app {} does not export `__app_version`",
                         app
                     )
                 })?;
@@ -383,7 +383,7 @@ impl AppRunner {
             let exported_version = typed.call(&mut store, ())?;
             ensure!(
                 exported_version == versioned_app.version,
-                "Wasm `__charms_version` ({}) does not match spell version ({}) for app {}",
+                "Wasm `__app_version` ({}) does not match spell version ({}) for app {}",
                 exported_version,
                 versioned_app.version,
                 app

--- a/charms-app-runner/src/lib.rs
+++ b/charms-app-runner/src/lib.rs
@@ -429,11 +429,11 @@ impl AppRunner {
             .map(|(app, x)| {
                 let w = app_private_inputs.get(app).unwrap_or(&empty);
                 if x.is_empty() && w.is_empty() && is_simple_transfer(app, tx) {
-                    ensure!(
-                        !versioned_apps.contains_key(&app.vk),
-                        "versioned app cannot be skipped as a simple transfer: {}",
-                        app
-                    );
+                    // Versioned simple transfers are allowed: the spell-level
+                    // `check_app_version_continuity` has already verified that the
+                    // version (and therefore the Wasm hash) stays unchanged, and the
+                    // previous spell already authenticated `(vk, version, wasm_hash)` --
+                    // so no fresh binary or signature is needed here.
                     eprintln!("➡️  simple transfer w.r.t. app: {}", app);
                     return Ok(0);
                 }

--- a/charms-app-runner/src/lib.rs
+++ b/charms-app-runner/src/lib.rs
@@ -1,13 +1,14 @@
 use anyhow::{Result, bail, ensure};
-use charms_data::{App, B32, Data, Transaction, is_simple_transfer, util};
+use charms_data::{App, AppSignature, B32, Data, Transaction, VersionedApp, is_simple_transfer, util};
 use rand::{RngExt, SeedableRng, rngs::StdRng};
+use secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeMap,
     io::Write,
     sync::{Arc, Mutex},
 };
-use wasmi::{Caller, CompilationMode, Config, Engine, Extern, Linker, Memory, Module, Store};
+use wasmi::{Caller, CompilationMode, Config, Engine, Extern, Linker, Memory, Module, Store, TypedFunc};
 
 #[derive(Clone)]
 pub struct AppRunner {
@@ -263,6 +264,66 @@ impl AppRunner {
         B32(hash.into())
     }
 
+    /// Verify that `app_binary` is the correct binary for `app`, either as a simple (immutable)
+    /// app where `app.vk == SHA256(binary)`, or as a versioned app where the binary hash matches
+    /// the spell's [`VersionedApp::wasm_hash`] and is signed by a key whose SHA256 equals
+    /// `app.vk`. Returns the SHA256 hash of the binary.
+    fn verify_app_binary(
+        &self,
+        app: &App,
+        app_binary: &[u8],
+        versioned_apps: &BTreeMap<B32, VersionedApp>,
+        app_signatures: &BTreeMap<B32, AppSignature>,
+    ) -> Result<B32> {
+        let binary_hash = self.vk(app_binary);
+        match versioned_apps.get(&app.vk) {
+            None => {
+                ensure!(
+                    !app_signatures.contains_key(&app.vk),
+                    "signature provided for non-versioned app: {}",
+                    app
+                );
+                ensure!(
+                    app.vk == binary_hash,
+                    "app.vk mismatch (binary hash) for app: {}",
+                    app
+                );
+            }
+            Some(versioned_app) => {
+                ensure!(
+                    versioned_app.wasm_hash == binary_hash,
+                    "Wasm hash mismatch for versioned app: {}",
+                    app
+                );
+                let sig = app_signatures.get(&app.vk).ok_or_else(|| {
+                    anyhow::anyhow!("missing signature for versioned app: {}", app)
+                })?;
+                let pk_hash = self.vk(&sig.public_key.0);
+                ensure!(
+                    pk_hash == app.vk,
+                    "public key hash does not match app.vk: {}",
+                    app
+                );
+                let xonly_pk = XOnlyPublicKey::from_slice(&sig.public_key.0).map_err(|e| {
+                    anyhow::anyhow!("invalid BIP-340 x-only public key for {}: {}", app, e)
+                })?;
+                let signature = schnorr::Signature::from_slice(&sig.signature).map_err(|e| {
+                    anyhow::anyhow!("invalid BIP-340 Schnorr signature for {}: {}", app, e)
+                })?;
+                let msg = Message::from_digest(binary_hash.0);
+                let secp = Secp256k1::verification_only();
+                secp.verify_schnorr(&signature, &msg, &xonly_pk).map_err(|e| {
+                    anyhow::anyhow!(
+                        "BIP-340 Schnorr signature verification failed for {}: {}",
+                        app,
+                        e
+                    )
+                })?;
+            }
+        }
+        Ok(binary_hash)
+    }
+
     pub fn run(
         &self,
         app_binary: &[u8],
@@ -270,9 +331,10 @@ impl AppRunner {
         tx: &Transaction,
         x: &Data,
         w: &Data,
+        versioned_apps: &BTreeMap<B32, VersionedApp>,
+        app_signatures: &BTreeMap<B32, AppSignature>,
     ) -> Result<u64> {
-        let vk = self.vk(app_binary);
-        ensure!(app.vk == vk, "app.vk mismatch");
+        self.verify_app_binary(app, app_binary, versioned_apps, app_signatures)?;
 
         let stdin_content = util::write(&(app, tx, x, w))?;
 
@@ -308,6 +370,26 @@ impl AppRunner {
 
         let instance = linker.instantiate_and_start(&mut store, &module)?;
 
+        if let Some(versioned_app) = versioned_apps.get(&app.vk) {
+            let version_func = instance
+                .get_func(&store, "__charms_version")
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "versioned app {} does not export `__charms_version`",
+                        app
+                    )
+                })?;
+            let typed: TypedFunc<(), u32> = version_func.typed(&store)?;
+            let exported_version = typed.call(&mut store, ())?;
+            ensure!(
+                exported_version == versioned_app.version,
+                "Wasm `__charms_version` ({}) does not match spell version ({}) for app {}",
+                exported_version,
+                versioned_app.version,
+                app
+            );
+        }
+
         let Some(main_func) = instance.get_func(&store, "_start") else {
             bail!("we should have a main function")
         };
@@ -327,6 +409,8 @@ impl AppRunner {
     pub fn run_all(
         &self,
         app_binaries: &BTreeMap<B32, Vec<u8>>,
+        versioned_apps: &BTreeMap<B32, VersionedApp>,
+        app_signatures: &BTreeMap<B32, AppSignature>,
         tx: &Transaction,
         app_public_inputs: &BTreeMap<App, Data>,
         app_private_inputs: &BTreeMap<App, Data>,
@@ -337,12 +421,22 @@ impl AppRunner {
             .map(|(app, x)| {
                 let w = app_private_inputs.get(app).unwrap_or(&empty);
                 if x.is_empty() && w.is_empty() && is_simple_transfer(app, tx) {
+                    ensure!(
+                        !versioned_apps.contains_key(&app.vk),
+                        "versioned app cannot be skipped as a simple transfer: {}",
+                        app
+                    );
                     eprintln!("➡️  simple transfer w.r.t. app: {}", app);
                     return Ok(0);
                 }
-                match app_binaries.get(&app.vk) {
+                let binary_lookup_key = versioned_apps
+                    .get(&app.vk)
+                    .map(|va| &va.wasm_hash)
+                    .unwrap_or(&app.vk);
+                match app_binaries.get(binary_lookup_key) {
                     Some(app_binary) => {
-                        let cycles = self.run(app_binary, app, tx, x, w)?;
+                        let cycles =
+                            self.run(app_binary, app, tx, x, w, versioned_apps, app_signatures)?;
                         eprintln!("✅  app contract satisfied: {}", app);
                         Ok(cycles)
                     }

--- a/charms-app-runner/src/lib.rs
+++ b/charms-app-runner/src/lib.rs
@@ -3,16 +3,24 @@ use charms_data::{
     App, AppSignature, B32, Data, Transaction, VersionedApp, is_simple_transfer, util,
 };
 use rand::{RngExt, SeedableRng, rngs::StdRng};
-use secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr};
+use secp256k1::{Message, Secp256k1, VerifyOnly, XOnlyPublicKey, schnorr};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeMap,
     io::Write,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 use wasmi::{
     Caller, CompilationMode, Config, Engine, Extern, Linker, Memory, Module, Store, TypedFunc,
 };
+
+/// Single shared verification-only secp256k1 context. The context owns precomputed tables
+/// (~1 MB) and is expensive to allocate; `verify_app_binary` may be called many times per
+/// spell, so we build it once and reuse.
+fn secp_verifier() -> &'static Secp256k1<VerifyOnly> {
+    static CTX: OnceLock<Secp256k1<VerifyOnly>> = OnceLock::new();
+    CTX.get_or_init(Secp256k1::verification_only)
+}
 
 #[derive(Clone)]
 pub struct AppRunner {
@@ -315,8 +323,8 @@ impl AppRunner {
                     anyhow::anyhow!("invalid BIP-340 Schnorr signature for {}: {}", app, e)
                 })?;
                 let msg = Message::from_digest(binary_hash.0);
-                let secp = Secp256k1::verification_only();
-                secp.verify_schnorr(&signature, &msg, &xonly_pk)
+                secp_verifier()
+                    .verify_schnorr(&signature, &msg, &xonly_pk)
                     .map_err(|e| {
                         anyhow::anyhow!(
                             "BIP-340 Schnorr signature verification failed for {}: {}",

--- a/charms-app-runner/src/lib.rs
+++ b/charms-app-runner/src/lib.rs
@@ -1,5 +1,7 @@
 use anyhow::{Result, bail, ensure};
-use charms_data::{App, AppSignature, B32, Data, Transaction, VersionedApp, is_simple_transfer, util};
+use charms_data::{
+    App, AppSignature, B32, Data, Transaction, VersionedApp, is_simple_transfer, util,
+};
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 use secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr};
 use sha2::{Digest, Sha256};
@@ -8,7 +10,9 @@ use std::{
     io::Write,
     sync::{Arc, Mutex},
 };
-use wasmi::{Caller, CompilationMode, Config, Engine, Extern, Linker, Memory, Module, Store, TypedFunc};
+use wasmi::{
+    Caller, CompilationMode, Config, Engine, Extern, Linker, Memory, Module, Store, TypedFunc,
+};
 
 #[derive(Clone)]
 pub struct AppRunner {
@@ -312,13 +316,14 @@ impl AppRunner {
                 })?;
                 let msg = Message::from_digest(binary_hash.0);
                 let secp = Secp256k1::verification_only();
-                secp.verify_schnorr(&signature, &msg, &xonly_pk).map_err(|e| {
-                    anyhow::anyhow!(
-                        "BIP-340 Schnorr signature verification failed for {}: {}",
-                        app,
-                        e
-                    )
-                })?;
+                secp.verify_schnorr(&signature, &msg, &xonly_pk)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "BIP-340 Schnorr signature verification failed for {}: {}",
+                            app,
+                            e
+                        )
+                    })?;
             }
         }
         Ok(binary_hash)
@@ -371,14 +376,9 @@ impl AppRunner {
         let instance = linker.instantiate_and_start(&mut store, &module)?;
 
         if let Some(versioned_app) = versioned_apps.get(&app.vk) {
-            let version_func = instance
-                .get_func(&store, "__app_version")
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "versioned app {} does not export `__app_version`",
-                        app
-                    )
-                })?;
+            let version_func = instance.get_func(&store, "__app_version").ok_or_else(|| {
+                anyhow::anyhow!("versioned app {} does not export `__app_version`", app)
+            })?;
             let typed: TypedFunc<(), u32> = version_func.typed(&store)?;
             let exported_version = typed.call(&mut store, ())?;
             ensure!(

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -476,11 +476,25 @@ pub fn check_app_version_continuity(
         let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
             Some(beam_source) => {
                 let beam_source_utxo_id = &beam_source.0;
-                let (prev_spell, _) = &prev_spells[&beam_source_utxo_id.0];
+                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(
+                    || {
+                        anyhow!(
+                            "missing prev spell for beam source utxo {} (input #{})",
+                            beam_source_utxo_id,
+                            i
+                        )
+                    },
+                )?;
                 (prev_spell, beam_source_utxo_id)
             }
             None => {
-                let (prev_spell, _) = &prev_spells[&input_utxo_id.0];
+                let (prev_spell, _) = prev_spells.get(&input_utxo_id.0).ok_or_else(|| {
+                    anyhow!(
+                        "missing prev spell for input utxo {} (input #{})",
+                        input_utxo_id,
+                        i
+                    )
+                })?;
                 (prev_spell, input_utxo_id)
             }
         };

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -395,6 +395,7 @@ pub fn is_correct(
         .collect();
     ensure!(all_prev_txids == prev_spells.keys().collect());
 
+    ensure_no_orphan_versioned_apps(spell)?;
     check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
 
@@ -423,6 +424,27 @@ pub fn is_correct(
     }
 
     Ok(true)
+}
+
+/// Every entry in `spell.versioned_apps` must correspond to at least one app in
+/// `spell.app_public_inputs`. Without this, a prover bypassing the host-side validator
+/// could commit a spell carrying "orphan" version pins for vks no app references —
+/// those orphans then become part of `prev_spells` for any future spend, where
+/// [`check_prev_versioned_apps_consistency`] would happily compare them and could
+/// reject otherwise-valid spends whose other prev spell legitimately pinned the same
+/// `(vk, version)` to a different `wasm_hash`. The check therefore lives inside
+/// [`is_correct`] (the function whose output is committed to the zkVM proof), not just
+/// in host-side request validation.
+pub fn ensure_no_orphan_versioned_apps(spell: &NormalizedSpell) -> anyhow::Result<()> {
+    let app_vks: BTreeSet<&B32> = spell.app_public_inputs.keys().map(|app| &app.vk).collect();
+    for vk in spell.versioned_apps.keys() {
+        ensure!(
+            app_vks.contains(vk),
+            "versioned_apps contains unused vk: {}",
+            vk
+        );
+    }
+    Ok(())
 }
 
 /// Every app that appears in any spent input UTXO's charms MUST also appear in the
@@ -1253,6 +1275,42 @@ mod test {
             (prev_spell_with_versioned(&app.vk, versioned(4, HASH_B)), 1),
         );
         check_prev_versioned_apps_consistency(&prev_spells).unwrap();
+    }
+
+    #[test]
+    fn orphan_versioned_apps_rejected() {
+        // versioned_apps lists a vk that doesn't appear in any app in app_public_inputs.
+        // This must be rejected by `is_correct` (and so by the zkVM proof), not just by
+        // the host-side validator.
+        let app = an_app();
+        let other_vk = b32(
+            "9999999999999999999999999999999999999999999999999999999999999999",
+        );
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![]);
+        spell.tx.outs = vec![];
+        spell.app_public_inputs.insert(app, Data::empty());
+        spell
+            .versioned_apps
+            .insert(other_vk.clone(), versioned(1, HASH_A));
+        let err = ensure_no_orphan_versioned_apps(&spell)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unused vk"), "got: {err}");
+        assert!(err.contains(&other_vk.to_string()), "got: {err}");
+    }
+
+    #[test]
+    fn no_orphan_when_vk_is_referenced() {
+        let app = an_app();
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![]);
+        spell.tx.outs = vec![];
+        spell.app_public_inputs.insert(app.clone(), Data::empty());
+        spell
+            .versioned_apps
+            .insert(app.vk.clone(), versioned(1, HASH_A));
+        ensure_no_orphan_versioned_apps(&spell).unwrap();
     }
 
     #[test]

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -395,6 +395,8 @@ pub fn is_correct(
         .collect();
     ensure!(all_prev_txids == prev_spells.keys().collect());
 
+    check_app_version_continuity(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
+
     let apps = apps(spell);
 
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
@@ -415,6 +417,97 @@ pub fn is_correct(
     }
 
     Ok(true)
+}
+
+/// Enforce versioned-app continuity from spent charms to the spending spell:
+///
+/// 1. If the app version stays the same, the Wasm binary hash MUST stay the same.
+/// 2. The app version in the spending spell MUST be the same, higher, or `0`.
+/// 3. If the spent charm's app version is `0`, the spending spell's version MUST also be `0`.
+///
+/// The check is per-input-UTXO, per-app-vk. For beamed inputs, the "previous" spell is the
+/// beam source's spell (since that is where the spent charm's metadata lives).
+pub fn check_app_version_continuity(
+    spell: &NormalizedSpell,
+    prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
+    tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
+) -> anyhow::Result<()> {
+    let Some(tx_ins) = &spell.tx.ins else {
+        unreachable!("called after well_formed");
+    };
+
+    for (i, input_utxo_id) in tx_ins.iter().enumerate() {
+        // Resolve which prev spell + utxo carries the spent charms (handling beaming).
+        let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
+            Some(beam_source) => {
+                let beam_source_utxo_id = &beam_source.0;
+                let (prev_spell, _) = &prev_spells[&beam_source_utxo_id.0];
+                (prev_spell, beam_source_utxo_id)
+            }
+            None => {
+                let (prev_spell, _) = &prev_spells[&input_utxo_id.0];
+                (prev_spell, input_utxo_id)
+            }
+        };
+
+        let Some(prev_charms) = charms_in_utxo(source_spell, source_utxo_id) else {
+            continue;
+        };
+
+        for app in prev_charms.keys() {
+            let Some(prev_ver) = source_spell.versioned_apps.get(&app.vk) else {
+                continue;
+            };
+
+            // Only enforce when the spending spell also references this vk.
+            let referenced = spell.app_public_inputs.keys().any(|a| a.vk == app.vk);
+            if !referenced {
+                continue;
+            }
+
+            let cur_ver = spell.versioned_apps.get(&app.vk).ok_or_else(|| {
+                anyhow!(
+                    "spent charm with versioned app {} is referenced in the spending spell, but \
+                     the spending spell does not declare it in `versioned_apps`",
+                    app
+                )
+            })?;
+
+            // Rule 3: prev version 0 is sticky.
+            if prev_ver.version == 0 {
+                ensure!(
+                    cur_ver.version == 0,
+                    "app {}: spent version is 0, spending spell version must also be 0 (got {})",
+                    app,
+                    cur_ver.version
+                );
+            } else {
+                // Rule 2: spending version must be same, higher, or 0.
+                ensure!(
+                    cur_ver.version == 0 || cur_ver.version >= prev_ver.version,
+                    "app {}: spending version ({}) must be 0, equal to, or higher than the \
+                     spent version ({})",
+                    app,
+                    cur_ver.version,
+                    prev_ver.version
+                );
+            }
+
+            // Rule 1: same version implies same Wasm binary hash.
+            if cur_ver.version == prev_ver.version {
+                ensure!(
+                    cur_ver.wasm_hash == prev_ver.wasm_hash,
+                    "app {}: spending and spent versions are both {}, but Wasm hashes differ \
+                     (spent: {}, spending: {})",
+                    app,
+                    cur_ver.version,
+                    prev_ver.wasm_hash,
+                    cur_ver.wasm_hash
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn beaming_txs_have_finality_proofs(
@@ -480,12 +573,234 @@ pub fn beamed_out_to_hash(spell: &NormalizedSpell, i: u32) -> Option<&B32> {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::{BeamSource, NormalizedSpell};
-    use charms_data::{UtxoId, util};
+    use charms_data::{App, Data, NativeOutput, UtxoId, VersionedApp, util};
+    use std::str::FromStr;
     use test_strategy::proptest;
 
     #[test]
     fn dummy() {}
+
+    fn b32(hex: &str) -> B32 {
+        B32::from_str(hex).unwrap()
+    }
+
+    /// Build a `(spell, prev_spells)` pair where the spending spell has a single input UTXO
+    /// pointing at a previous spell whose output 0 carries one charm for `app`.
+    fn build_continuity_fixture(
+        app: App,
+        prev_ver: Option<VersionedApp>,
+        cur_ver: Option<VersionedApp>,
+        reference_in_spending: bool,
+    ) -> (NormalizedSpell, BTreeMap<TxId, (NormalizedSpell, usize)>) {
+        let prev_tx_id =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let prev_utxo = UtxoId(prev_tx_id, 0);
+
+        let mut prev_spell = NormalizedSpell::default();
+        prev_spell.tx.ins = Some(vec![]);
+        prev_spell.tx.refs = Some(vec![]);
+        prev_spell.tx.outs = vec![{
+            let mut c = NormalizedCharms::new();
+            c.insert(0, Data::empty());
+            c
+        }];
+        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
+            amount: 0,
+            dest: vec![],
+            content: None,
+        });
+        prev_spell.app_public_inputs.insert(app.clone(), Data::empty());
+        if let Some(v) = prev_ver {
+            prev_spell.versioned_apps.insert(app.vk.clone(), v);
+        }
+
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![prev_utxo.clone()]);
+        spell.tx.outs = vec![];
+        if reference_in_spending {
+            spell.app_public_inputs.insert(app.clone(), Data::empty());
+        }
+        if let Some(v) = cur_ver {
+            spell.versioned_apps.insert(app.vk.clone(), v);
+        }
+
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(prev_tx_id, (prev_spell, 1usize));
+        (spell, prev_spells)
+    }
+
+    fn versioned(version: u32, hash_hex: &str) -> VersionedApp {
+        VersionedApp {
+            version,
+            wasm_hash: b32(hash_hex),
+        }
+    }
+
+    fn an_app() -> App {
+        App::from_str(
+            "t/2222222222222222222222222222222222222222222222222222222222222222/\
+             3333333333333333333333333333333333333333333333333333333333333333",
+        )
+        .unwrap()
+    }
+
+    const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    #[test]
+    fn continuity_same_version_same_hash_ok() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(3, HASH_A)),
+            Some(versioned(3, HASH_A)),
+            true,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn continuity_same_version_different_hash_rejected() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(3, HASH_A)),
+            Some(versioned(3, HASH_B)),
+            true,
+        );
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Wasm hashes differ"), "got: {err}");
+    }
+
+    #[test]
+    fn continuity_higher_version_ok() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(3, HASH_A)),
+            Some(versioned(7, HASH_B)),
+            true,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn continuity_lower_version_rejected() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(7, HASH_A)),
+            Some(versioned(3, HASH_B)),
+            true,
+        );
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be 0, equal to, or higher"), "got: {err}");
+    }
+
+    #[test]
+    fn continuity_drop_to_zero_from_positive_ok() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(5, HASH_A)),
+            Some(versioned(0, HASH_B)),
+            true,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn continuity_zero_to_nonzero_rejected() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(0, HASH_A)),
+            Some(versioned(1, HASH_A)),
+            true,
+        );
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("spent version is 0"), "got: {err}");
+    }
+
+    #[test]
+    fn continuity_zero_to_zero_same_hash_ok() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(0, HASH_A)),
+            Some(versioned(0, HASH_A)),
+            true,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn continuity_zero_to_zero_different_hash_rejected() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(0, HASH_A)),
+            Some(versioned(0, HASH_B)),
+            true,
+        );
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Wasm hashes differ"), "got: {err}");
+    }
+
+    #[test]
+    fn continuity_versioned_in_prev_missing_in_spending_rejected() {
+        let app = an_app();
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(3, HASH_A)),
+            None,
+            true,
+        );
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not declare it in `versioned_apps`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn continuity_skipped_when_spending_does_not_reference_vk() {
+        let app = an_app();
+        // Prev declares versioned, spending doesn't reference the app at all (e.g. burn).
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            Some(versioned(3, HASH_A)),
+            None,
+            false,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn continuity_skipped_when_prev_is_not_versioned() {
+        let app = an_app();
+        // Prev treats it as a simple app (no entry in versioned_apps).
+        let (spell, prev_spells) = build_continuity_fixture(
+            app,
+            None,
+            Some(versioned(2, HASH_A)),
+            true,
+        );
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
 
     #[test]
     fn decode_cbor() {

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -395,6 +395,7 @@ pub fn is_correct(
         .collect();
     ensure!(all_prev_txids == prev_spells.keys().collect());
 
+    check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
     check_app_version_continuity(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
 
@@ -418,6 +419,69 @@ pub fn is_correct(
     }
 
     Ok(true)
+}
+
+/// Every app that appears in any spent input UTXO's charms MUST also appear in the
+/// spell's `app_public_inputs`. Without this rule, a spell could spend an input carrying
+/// a charm for app `X` without listing `X` — `apps_satisfied` iterates only
+/// `app_public_inputs`, so `X`'s contract would be bypassed entirely. For a token that
+/// lets value be burned without authorization; for an NFT it lets the NFT be destroyed
+/// without the app's permission.
+///
+/// For beamed inputs the "spent charms" come from the beam source's spell, so we resolve
+/// the source spell + utxo the same way [`check_app_version_continuity`] does.
+pub fn check_input_apps_are_referenced(
+    spell: &NormalizedSpell,
+    prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
+    tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
+) -> anyhow::Result<()> {
+    let Some(tx_ins) = &spell.tx.ins else {
+        unreachable!("called after well_formed");
+    };
+    let referenced: BTreeSet<&App> = spell.app_public_inputs.keys().collect();
+
+    for (i, input_utxo_id) in tx_ins.iter().enumerate() {
+        let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
+            Some(beam_source) => {
+                let beam_source_utxo_id = &beam_source.0;
+                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(
+                    || {
+                        anyhow!(
+                            "missing prev spell for beam source utxo {} (input #{})",
+                            beam_source_utxo_id,
+                            i
+                        )
+                    },
+                )?;
+                (prev_spell, beam_source_utxo_id)
+            }
+            None => {
+                let (prev_spell, _) = prev_spells.get(&input_utxo_id.0).ok_or_else(|| {
+                    anyhow!(
+                        "missing prev spell for input utxo {} (input #{})",
+                        input_utxo_id,
+                        i
+                    )
+                })?;
+                (prev_spell, input_utxo_id)
+            }
+        };
+        let Some(input_charms) = charms_in_utxo(source_spell, source_utxo_id) else {
+            continue;
+        };
+        for app in input_charms.keys() {
+            ensure!(
+                referenced.contains(app),
+                "input #{} ({}) carries a charm for app {}, but the spending spell does not \
+                 list it in `app_public_inputs`. Spending (or burning) the charm requires \
+                 the app to be referenced so its contract can authorize the operation.",
+                i,
+                source_utxo_id,
+                app
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Enforce that all `prev_spells` agree on the Wasm binary hash for any `(vk, version)`
@@ -468,9 +532,12 @@ pub fn check_prev_versioned_apps_consistency(
 ///   don't "spend" a charm, so the version-bump rules don't apply. Cross-tx version
 ///   consistency for ref-source spells is still enforced by
 ///   [`check_prev_versioned_apps_consistency`], which sees every prev spell.
-/// - When a spent versioned charm's `vk` is not referenced at all by the spending spell's
-///   `app_public_inputs` (e.g. an outright burn), continuity is **skipped**: there is no
-///   successor `(version, wasm_hash)` to constrain.
+/// - This function tolerates the case where a spent charm's `vk` is not referenced by the
+///   spending spell (no successor `(version, wasm_hash)` to constrain). In the full
+///   `is_correct` flow that situation is independently rejected earlier by
+///   [`check_input_apps_are_referenced`], because allowing it would let an app's contract
+///   be bypassed entirely. Keeping the local tolerance here makes this function a pure
+///   per-input rule that can be reasoned about in isolation.
 pub fn check_app_version_continuity(
     spell: &NormalizedSpell,
     prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
@@ -864,6 +931,57 @@ mod test {
         let (spell, prev_spells) =
             build_continuity_fixture(app, None, Some(versioned(2, HASH_A)), true);
         check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn input_apps_referenced_ok_when_listed() {
+        let app = an_app();
+        // Prev output 0 carries a charm for `app`; spending spell references `app`.
+        let (spell, prev_spells) = build_continuity_fixture(app, None, None, true);
+        check_input_apps_are_referenced(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    #[test]
+    fn input_apps_referenced_burn_without_reference_rejected() {
+        let app = an_app();
+        // Prev output 0 carries a charm for `app`; spending spell omits it entirely
+        // (the soundness-bug scenario: attempting to burn without authorizing the app).
+        let (spell, prev_spells) = build_continuity_fixture(app, None, None, false);
+        let err = check_input_apps_are_referenced(&spell, &prev_spells, &BTreeMap::new())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not list it in `app_public_inputs`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn input_apps_referenced_no_input_charms_ok() {
+        // Input UTXO has no charms attached -> nothing to require.
+        let prev_tx_id = TxId::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let prev_utxo = UtxoId(prev_tx_id, 0);
+
+        let mut prev_spell = NormalizedSpell::default();
+        prev_spell.tx.ins = Some(vec![]);
+        prev_spell.tx.refs = Some(vec![]);
+        prev_spell.tx.outs = vec![NormalizedCharms::new()]; // empty charms
+        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
+            amount: 0,
+            dest: vec![],
+            content: None,
+        });
+
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![prev_utxo]);
+        spell.tx.outs = vec![];
+
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(prev_tx_id, (prev_spell, 1usize));
+        check_input_apps_are_referenced(&spell, &prev_spells, &BTreeMap::new()).unwrap();
     }
 
     fn prev_spell_with_versioned(vk: &B32, va: VersionedApp) -> NormalizedSpell {

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -462,6 +462,15 @@ pub fn check_prev_versioned_apps_consistency(
 ///
 /// The check is per-input-UTXO, per-app-vk. For beamed inputs, the "previous" spell is the
 /// beam source's spell (since that is where the spent charm's metadata lives).
+///
+/// Scope notes:
+/// - Reference inputs (`spell.tx.refs`) are **not** consulted here: refs are read-only and
+///   don't "spend" a charm, so the version-bump rules don't apply. Cross-tx version
+///   consistency for ref-source spells is still enforced by
+///   [`check_prev_versioned_apps_consistency`], which sees every prev spell.
+/// - When a spent versioned charm's `vk` is not referenced at all by the spending spell's
+///   `app_public_inputs` (e.g. an outright burn), continuity is **skipped**: there is no
+///   successor `(version, wasm_hash)` to constrain.
 pub fn check_app_version_continuity(
     spell: &NormalizedSpell,
     prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
@@ -508,7 +517,9 @@ pub fn check_app_version_continuity(
                 continue;
             };
 
-            // Only enforce when the spending spell also references this vk.
+            // Burn / drop: the spending spell doesn't reference this vk at all, so there
+            // is no successor (version, wasm_hash) to constrain. The charm is being
+            // destroyed (or transferred without invoking this app), which is allowed.
             let referenced = spell.app_public_inputs.keys().any(|a| a.vk == app.vk);
             if !referenced {
                 continue;
@@ -516,8 +527,11 @@ pub fn check_app_version_continuity(
 
             let cur_ver = spell.versioned_apps.get(&app.vk).ok_or_else(|| {
                 anyhow!(
-                    "spent charm with versioned app {} is referenced in the spending spell, but \
-                     the spending spell does not declare it in `versioned_apps`",
+                    "input #{} ({}): spent charm with versioned app {} is referenced in the \
+                     spending spell, but the spending spell does not declare it in \
+                     `versioned_apps`",
+                    i,
+                    source_utxo_id,
                     app
                 )
             })?;
@@ -526,7 +540,10 @@ pub fn check_app_version_continuity(
             if prev_ver.version == 0 {
                 ensure!(
                     cur_ver.version == 0,
-                    "app {}: spent version is 0, spending spell version must also be 0 (got {})",
+                    "input #{} ({}), app {}: spent version is 0, spending spell version must \
+                     also be 0 (got {})",
+                    i,
+                    source_utxo_id,
                     app,
                     cur_ver.version
                 );
@@ -534,8 +551,10 @@ pub fn check_app_version_continuity(
                 // Rule 2: spending version must be same, higher, or 0.
                 ensure!(
                     cur_ver.version == 0 || cur_ver.version >= prev_ver.version,
-                    "app {}: spending version ({}) must be 0, equal to, or higher than the \
-                     spent version ({})",
+                    "input #{} ({}), app {}: spending version ({}) must be 0, equal to, or \
+                     higher than the spent version ({})",
+                    i,
+                    source_utxo_id,
                     app,
                     cur_ver.version,
                     prev_ver.version
@@ -546,8 +565,10 @@ pub fn check_app_version_continuity(
             if cur_ver.version == prev_ver.version {
                 ensure!(
                     cur_ver.wasm_hash == prev_ver.wasm_hash,
-                    "app {}: spending and spent versions are both {}, but Wasm hashes differ \
-                     (spent: {}, spending: {})",
+                    "input #{} ({}), app {}: spending and spent versions are both {}, but Wasm \
+                     hashes differ (spent: {}, spending: {})",
+                    i,
+                    source_utxo_id,
                     app,
                     cur_ver.version,
                     prev_ver.wasm_hash,

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -395,6 +395,7 @@ pub fn is_correct(
         .collect();
     ensure!(all_prev_txids == prev_spells.keys().collect());
 
+    check_prev_versioned_apps_consistency(&prev_spells)?;
     check_app_version_continuity(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
 
     let apps = apps(spell);
@@ -419,11 +420,45 @@ pub fn is_correct(
     Ok(true)
 }
 
+/// Enforce that all `prev_spells` agree on the Wasm binary hash for any `(vk, version)`
+/// pair they share. A spending spell references several previous transactions and each one
+/// independently declares `versioned_apps`; this check rejects the case where two of them
+/// claim the same vk + version but bind it to different binaries.
+pub fn check_prev_versioned_apps_consistency(
+    prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
+) -> anyhow::Result<()> {
+    let mut seen: BTreeMap<(&B32, u32), (&B32, &TxId)> = BTreeMap::new();
+    for (tx_id, (prev_spell, _)) in prev_spells {
+        for (vk, va) in &prev_spell.versioned_apps {
+            let key = (vk, va.version);
+            match seen.get(&key) {
+                Some((prev_hash, prev_source)) => {
+                    ensure!(
+                        *prev_hash == &va.wasm_hash,
+                        "inconsistent Wasm hash for versioned app (vk={}, version={}): {} (in tx {}) vs {} (in tx {})",
+                        vk,
+                        va.version,
+                        prev_hash,
+                        prev_source,
+                        va.wasm_hash,
+                        tx_id
+                    );
+                }
+                None => {
+                    seen.insert(key, (&va.wasm_hash, tx_id));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Enforce versioned-app continuity from spent charms to the spending spell:
 ///
 /// 1. If the app version stays the same, the Wasm binary hash MUST stay the same.
 /// 2. The app version in the spending spell MUST be the same, higher, or `0`.
-/// 3. If the spent charm's app version is `0`, the spending spell's version MUST also be `0`.
+/// 3. Version `0` is immutable: if the spent charm's app version is `0`, the spending spell's
+///    version MUST also be `0`.
 ///
 /// The check is per-input-UTXO, per-app-vk. For beamed inputs, the "previous" spell is the
 /// beam source's spell (since that is where the spent charm's metadata lives).
@@ -473,7 +508,7 @@ pub fn check_app_version_continuity(
                 )
             })?;
 
-            // Rule 3: prev version 0 is sticky.
+            // Rule 3: version 0 is immutable.
             if prev_ver.version == 0 {
                 ensure!(
                     cur_ver.version == 0,
@@ -794,6 +829,87 @@ mod test {
         let (spell, prev_spells) =
             build_continuity_fixture(app, None, Some(versioned(2, HASH_A)), true);
         check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+    }
+
+    fn prev_spell_with_versioned(vk: &B32, va: VersionedApp) -> NormalizedSpell {
+        let mut s = NormalizedSpell::default();
+        s.tx.ins = Some(vec![]);
+        s.tx.outs = vec![];
+        s.versioned_apps.insert(vk.clone(), va);
+        s
+    }
+
+    #[test]
+    fn prev_versioned_apps_consistent_same_hash_ok() {
+        let app = an_app();
+        let tx1 = TxId::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let tx2 = TxId::from_str(
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(
+            tx1,
+            (prev_spell_with_versioned(&app.vk, versioned(3, HASH_A)), 1),
+        );
+        prev_spells.insert(
+            tx2,
+            (prev_spell_with_versioned(&app.vk, versioned(3, HASH_A)), 1),
+        );
+        check_prev_versioned_apps_consistency(&prev_spells).unwrap();
+    }
+
+    #[test]
+    fn prev_versioned_apps_different_hash_same_version_rejected() {
+        let app = an_app();
+        let tx1 = TxId::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let tx2 = TxId::from_str(
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(
+            tx1,
+            (prev_spell_with_versioned(&app.vk, versioned(3, HASH_A)), 1),
+        );
+        prev_spells.insert(
+            tx2,
+            (prev_spell_with_versioned(&app.vk, versioned(3, HASH_B)), 1),
+        );
+        let err = check_prev_versioned_apps_consistency(&prev_spells)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("inconsistent Wasm hash"), "got: {err}");
+    }
+
+    #[test]
+    fn prev_versioned_apps_different_versions_ok() {
+        // Same vk, different versions, different hashes — fine, they're different versions.
+        let app = an_app();
+        let tx1 = TxId::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let tx2 = TxId::from_str(
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(
+            tx1,
+            (prev_spell_with_versioned(&app.vk, versioned(3, HASH_A)), 1),
+        );
+        prev_spells.insert(
+            tx2,
+            (prev_spell_with_versioned(&app.vk, versioned(4, HASH_B)), 1),
+        );
+        check_prev_versioned_apps_consistency(&prev_spells).unwrap();
     }
 
     #[test]

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -607,12 +607,18 @@ mod test {
             c.insert(0, Data::empty());
             c
         }];
-        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
-            amount: 0,
-            dest: vec![],
-            content: None,
-        });
-        prev_spell.app_public_inputs.insert(app.clone(), Data::empty());
+        prev_spell
+            .tx
+            .coins
+            .get_or_insert_with(Vec::new)
+            .push(NativeOutput {
+                amount: 0,
+                dest: vec![],
+                content: None,
+            });
+        prev_spell
+            .app_public_inputs
+            .insert(app.clone(), Data::empty());
         if let Some(v) = prev_ver {
             prev_spell.versioned_apps.insert(app.vk.clone(), v);
         }
@@ -761,12 +767,8 @@ mod test {
     #[test]
     fn continuity_versioned_in_prev_missing_in_spending_rejected() {
         let app = an_app();
-        let (spell, prev_spells) = build_continuity_fixture(
-            app,
-            Some(versioned(3, HASH_A)),
-            None,
-            true,
-        );
+        let (spell, prev_spells) =
+            build_continuity_fixture(app, Some(versioned(3, HASH_A)), None, true);
         let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
             .unwrap_err()
             .to_string();
@@ -780,12 +782,8 @@ mod test {
     fn continuity_skipped_when_spending_does_not_reference_vk() {
         let app = an_app();
         // Prev declares versioned, spending doesn't reference the app at all (e.g. burn).
-        let (spell, prev_spells) = build_continuity_fixture(
-            app,
-            Some(versioned(3, HASH_A)),
-            None,
-            false,
-        );
+        let (spell, prev_spells) =
+            build_continuity_fixture(app, Some(versioned(3, HASH_A)), None, false);
         check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
     }
 
@@ -793,12 +791,8 @@ mod test {
     fn continuity_skipped_when_prev_is_not_versioned() {
         let app = an_app();
         // Prev treats it as a simple app (no entry in versioned_apps).
-        let (spell, prev_spells) = build_continuity_fixture(
-            app,
-            None,
-            Some(versioned(2, HASH_A)),
-            true,
-        );
+        let (spell, prev_spells) =
+            build_continuity_fixture(app, None, Some(versioned(2, HASH_A)), true);
         check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
     }
 

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -2,8 +2,8 @@ use crate::tx::{EnchantedTx, Tx, by_txid, extended_normalized_spell};
 use anyhow::{Context, anyhow, ensure};
 use charms_app_runner::AppRunner;
 use charms_data::{
-    App, AppInput, B32, Charms, Data, NativeOutput, TOKEN, Transaction, TxId, UtxoId, check,
-    is_simple_transfer,
+    App, AppInput, B32, Charms, Data, NativeOutput, TOKEN, Transaction, TxId, UtxoId, VersionedApp,
+    check, is_simple_transfer,
 };
 use const_format::formatcp;
 use serde::{Deserialize, Serialize};
@@ -154,6 +154,12 @@ pub struct NormalizedSpell {
     /// Maps all `App`s in the transaction to (potentially empty) public input data.
     #[serde(deserialize_with = "sorted_app_map::deserialize")]
     pub app_public_inputs: BTreeMap<App, Data>,
+    /// For versioned app modules: maps an app's `vk` (SHA256 of its signing public key) to the
+    /// `version` number and Wasm `wasm_hash` that this spell binds the app to. Apps whose `vk`
+    /// is absent from this map are simple (immutable): their `vk` is the SHA256 of their Wasm
+    /// binary directly.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub versioned_apps: BTreeMap<B32, VersionedApp>,
     /// Is this a mock spell?
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub mock: bool,
@@ -165,6 +171,7 @@ impl Default for NormalizedSpell {
             version: CURRENT_VERSION,
             tx: Default::default(),
             app_public_inputs: Default::default(),
+            versioned_apps: Default::default(),
             mock: false,
         }
     }
@@ -392,8 +399,19 @@ pub fn is_correct(
 
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
     match app_input {
-        None => ensure!(apps.iter().all(|app| is_simple_transfer(app, &charms_tx))),
-        Some(app_input) => apps_satisfied(&app_input, &spell.app_public_inputs, &charms_tx)?,
+        None => {
+            ensure!(
+                spell.versioned_apps.is_empty(),
+                "versioned apps require signatures and binaries"
+            );
+            ensure!(apps.iter().all(|app| is_simple_transfer(app, &charms_tx)));
+        }
+        Some(app_input) => apps_satisfied(
+            &app_input,
+            &spell.versioned_apps,
+            &spell.app_public_inputs,
+            &charms_tx,
+        )?,
     }
 
     Ok(true)
@@ -417,6 +435,7 @@ fn beaming_txs_have_finality_proofs(
 
 fn apps_satisfied(
     app_input: &AppInput,
+    versioned_apps: &BTreeMap<B32, VersionedApp>,
     app_public_inputs: &BTreeMap<App, Data>,
     tx: &Transaction,
 ) -> anyhow::Result<()> {
@@ -424,6 +443,8 @@ fn apps_satisfied(
     app_runner
         .run_all(
             &app_input.app_binaries,
+            versioned_apps,
+            &app_input.app_signatures,
             &tx,
             app_public_inputs,
             &app_input.app_private_inputs,

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -581,6 +581,19 @@ pub fn check_app_version_continuity(
         unreachable!("called after well_formed");
     };
 
+    // Inside the zkVM, redundant work is expensive: `is_simple_transfer` does a CBOR
+    // u64 parse per TOKEN charm (or builds two state multisets per NFT) on every call,
+    // and `app_public_inputs.keys().any(...)` is linear. Without hoisting, this loop
+    // was O(inputs * apps_per_input * (ins + outs)). Compute the per-app facts that
+    // don't change across input iterations once up front:
+    let referenced_vks: BTreeSet<&B32> =
+        spell.app_public_inputs.keys().map(|a| &a.vk).collect();
+    let simple_transfer_apps: BTreeSet<&App> = spell
+        .app_public_inputs
+        .keys()
+        .filter(|a| is_simple_transfer(a, tx))
+        .collect();
+
     for (i, input_utxo_id) in tx_ins.iter().enumerate() {
         // Resolve which prev spell + utxo carries the spent charms (handling beaming).
         let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
@@ -633,10 +646,11 @@ pub fn check_app_version_continuity(
             };
 
             // Burn / drop: the spending spell doesn't reference this vk at all, so there
-            // is no successor (version, wasm_hash) to constrain. The charm is being
-            // destroyed (or transferred without invoking this app), which is allowed.
-            let referenced = spell.app_public_inputs.keys().any(|a| a.vk == app.vk);
-            if !referenced {
+            // is no successor (version, wasm_hash) to constrain. In the full `is_correct`
+            // flow this is unreachable (`check_input_apps_are_referenced` rejects it
+            // first), but the function is also called in isolation by tests, so the
+            // local tolerance stays.
+            if !referenced_vks.contains(&app.vk) {
                 continue;
             }
 
@@ -654,7 +668,7 @@ pub fn check_app_version_continuity(
             // Rule 4: a simple transfer must not change the version. If you want to
             // upgrade, do something more than a transfer (so the app contract runs and
             // authorizes the bump explicitly).
-            if is_simple_transfer(app, tx) {
+            if simple_transfer_apps.contains(app) {
                 ensure!(
                     cur_ver.version == prev_ver.version,
                     "input #{} ({}), app {}: simple transfers must keep the version \

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -397,17 +397,21 @@ pub fn is_correct(
 
     check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
-    check_app_version_continuity(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
 
     let apps = apps(spell);
-
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
+
+    // Continuity (incl. the simple-transfer "version unchanged" rule) needs the resolved
+    // transaction to know which apps are simple transfers in this spell.
+    check_app_version_continuity(spell, &prev_spells, tx_ins_beamed_source_utxos, &charms_tx)?;
+
     match app_input {
         None => {
-            ensure!(
-                spell.versioned_apps.is_empty(),
-                "versioned apps require signatures and binaries"
-            );
+            // No binaries / signatures supplied -> every app must be a simple transfer.
+            // Versioned apps are allowed here: the continuity check has just verified
+            // that for every spent versioned charm the version stays unchanged (rule 4),
+            // which by rule 1 also pins the Wasm hash. The previous spell already
+            // authenticated `(vk, version, wasm_hash)`, so no fresh signature is needed.
             ensure!(apps.iter().all(|app| is_simple_transfer(app, &charms_tx)));
         }
         Some(app_input) => apps_satisfied(
@@ -523,6 +527,13 @@ pub fn check_prev_versioned_apps_consistency(
 /// 2. The app version in the spending spell MUST be the same, higher, or `0`.
 /// 3. Version `0` is immutable: if the spent charm's app version is `0`, the spending spell's
 ///    version MUST also be `0`.
+/// 4. If the spending spell is a [simple transfer][is_simple_transfer] for this app (token
+///    balance preserved / NFT state preserved), the app version MUST stay unchanged. This
+///    is strictly stronger than rule 2 for the simple-transfer case: you cannot upgrade an
+///    app via a transaction that only moves charms around. Combined with rule 1 it also
+///    pins the Wasm binary hash, which is why simple transfers don't need to supply the
+///    binary or a fresh signature at all -- the previous spell already authenticated
+///    `(vk, version, wasm_hash)`.
 ///
 /// The check is per-input-UTXO, per-app-vk. For beamed inputs, the "previous" spell is the
 /// beam source's spell (since that is where the spent charm's metadata lives).
@@ -542,6 +553,7 @@ pub fn check_app_version_continuity(
     spell: &NormalizedSpell,
     prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
     tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
+    tx: &Transaction,
 ) -> anyhow::Result<()> {
     let Some(tx_ins) = &spell.tx.ins else {
         unreachable!("called after well_formed");
@@ -581,6 +593,20 @@ pub fn check_app_version_continuity(
 
         for app in prev_charms.keys() {
             let Some(prev_ver) = source_spell.versioned_apps.get(&app.vk) else {
+                // Prev spell treated this app as a simple (immutable) app -- its `vk` is
+                // SHA-256 of the binary itself. The spending spell must continue to treat
+                // it as simple; introducing a `versioned_apps` entry here would silently
+                // re-anchor the charm to an arbitrary `(version, wasm_hash)` that nobody
+                // ever signed (the simple-transfer path would skip the signature check).
+                ensure!(
+                    !spell.versioned_apps.contains_key(&app.vk),
+                    "input #{} ({}), app {}: the spent charm is from a previous spell that \
+                     treated this app as simple (no `versioned_apps` entry); the spending \
+                     spell cannot retroactively declare it versioned",
+                    i,
+                    source_utxo_id,
+                    app
+                );
                 continue;
             };
 
@@ -603,8 +629,22 @@ pub fn check_app_version_continuity(
                 )
             })?;
 
-            // Rule 3: version 0 is immutable.
-            if prev_ver.version == 0 {
+            // Rule 4: a simple transfer must not change the version. If you want to
+            // upgrade, do something more than a transfer (so the app contract runs and
+            // authorizes the bump explicitly).
+            if is_simple_transfer(app, tx) {
+                ensure!(
+                    cur_ver.version == prev_ver.version,
+                    "input #{} ({}), app {}: simple transfers must keep the version \
+                     unchanged (spent: {}, spending: {})",
+                    i,
+                    source_utxo_id,
+                    app,
+                    prev_ver.version,
+                    cur_ver.version
+                );
+            } else if prev_ver.version == 0 {
+                // Rule 3: version 0 is immutable.
                 ensure!(
                     cur_ver.version == 0,
                     "input #{} ({}), app {}: spent version is 0, spending spell version must \
@@ -782,6 +822,15 @@ mod test {
         }
     }
 
+    /// Build the resolved `Transaction` for a fixture so we can pass it to
+    /// `check_app_version_continuity` (and exercise `is_simple_transfer`).
+    fn build_tx(
+        spell: &NormalizedSpell,
+        prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
+    ) -> Transaction {
+        to_tx(spell, prev_spells, &BTreeMap::new(), &[])
+    }
+
     fn an_app() -> App {
         App::from_str(
             "t/2222222222222222222222222222222222222222222222222222222222222222/\
@@ -802,7 +851,7 @@ mod test {
             Some(versioned(3, HASH_A)),
             true,
         );
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells)).unwrap();
     }
 
     #[test]
@@ -814,7 +863,7 @@ mod test {
             Some(versioned(3, HASH_B)),
             true,
         );
-        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells))
             .unwrap_err()
             .to_string();
         assert!(err.contains("Wasm hashes differ"), "got: {err}");
@@ -829,7 +878,7 @@ mod test {
             Some(versioned(7, HASH_B)),
             true,
         );
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells)).unwrap();
     }
 
     #[test]
@@ -841,7 +890,7 @@ mod test {
             Some(versioned(3, HASH_B)),
             true,
         );
-        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells))
             .unwrap_err()
             .to_string();
         assert!(err.contains("must be 0, equal to, or higher"), "got: {err}");
@@ -856,7 +905,7 @@ mod test {
             Some(versioned(0, HASH_B)),
             true,
         );
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells)).unwrap();
     }
 
     #[test]
@@ -868,7 +917,7 @@ mod test {
             Some(versioned(1, HASH_A)),
             true,
         );
-        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells))
             .unwrap_err()
             .to_string();
         assert!(err.contains("spent version is 0"), "got: {err}");
@@ -883,7 +932,7 @@ mod test {
             Some(versioned(0, HASH_A)),
             true,
         );
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells)).unwrap();
     }
 
     #[test]
@@ -895,7 +944,7 @@ mod test {
             Some(versioned(0, HASH_B)),
             true,
         );
-        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells))
             .unwrap_err()
             .to_string();
         assert!(err.contains("Wasm hashes differ"), "got: {err}");
@@ -906,7 +955,7 @@ mod test {
         let app = an_app();
         let (spell, prev_spells) =
             build_continuity_fixture(app, Some(versioned(3, HASH_A)), None, true);
-        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new())
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells))
             .unwrap_err()
             .to_string();
         assert!(
@@ -921,16 +970,157 @@ mod test {
         // Prev declares versioned, spending doesn't reference the app at all (e.g. burn).
         let (spell, prev_spells) =
             build_continuity_fixture(app, Some(versioned(3, HASH_A)), None, false);
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &build_tx(&spell, &prev_spells)).unwrap();
     }
 
     #[test]
-    fn continuity_skipped_when_prev_is_not_versioned() {
+    fn continuity_retro_versionizing_simple_app_rejected() {
         let app = an_app();
-        // Prev treats it as a simple app (no entry in versioned_apps).
+        // Prev treats it as a simple app (no `versioned_apps` entry). The spending
+        // spell tries to retroactively declare it versioned: rejected, because the
+        // simple-transfer path would otherwise accept arbitrary `(version, wasm_hash)`
+        // without anyone ever signing it.
         let (spell, prev_spells) =
             build_continuity_fixture(app, None, Some(versioned(2, HASH_A)), true);
-        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new()).unwrap();
+        let err = check_app_version_continuity(
+            &spell,
+            &prev_spells,
+            &BTreeMap::new(),
+            &build_tx(&spell, &prev_spells),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("cannot retroactively declare it versioned"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn continuity_simple_app_stays_simple_ok() {
+        let app = an_app();
+        // Both prev and current treat the app as simple. Continuity has nothing to
+        // enforce; the function is a no-op for this vk.
+        let (spell, prev_spells) = build_continuity_fixture(app, None, None, true);
+        check_app_version_continuity(
+            &spell,
+            &prev_spells,
+            &BTreeMap::new(),
+            &build_tx(&spell, &prev_spells),
+        )
+        .unwrap();
+    }
+
+    fn an_nft_app() -> App {
+        App::from_str(
+            "n/4444444444444444444444444444444444444444444444444444444444444444/\
+             5555555555555555555555555555555555555555555555555555555555555555",
+        )
+        .unwrap()
+    }
+
+    /// Build a spell pair where the prev spell has an NFT charm and the spending spell
+    /// mirrors it in its output (a "simple transfer"). Both sides may carry an optional
+    /// versioned-app entry for the NFT vk.
+    fn build_simple_nft_transfer_fixture(
+        app: App,
+        prev_ver: Option<VersionedApp>,
+        cur_ver: Option<VersionedApp>,
+    ) -> (NormalizedSpell, BTreeMap<TxId, (NormalizedSpell, usize)>) {
+        let prev_tx_id = TxId::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        let prev_utxo = UtxoId(prev_tx_id, 0);
+
+        let mut prev_spell = NormalizedSpell::default();
+        prev_spell.tx.ins = Some(vec![]);
+        prev_spell.tx.refs = Some(vec![]);
+        prev_spell.tx.outs = vec![{
+            let mut c = NormalizedCharms::new();
+            c.insert(0, Data::empty());
+            c
+        }];
+        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
+            amount: 0,
+            dest: vec![],
+            content: None,
+        });
+        prev_spell.app_public_inputs.insert(app.clone(), Data::empty());
+        if let Some(v) = prev_ver {
+            prev_spell.versioned_apps.insert(app.vk.clone(), v);
+        }
+
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![prev_utxo]);
+        spell.tx.outs = vec![{
+            let mut c = NormalizedCharms::new();
+            c.insert(0, Data::empty()); // mirror the input NFT state -> simple transfer
+            c
+        }];
+        spell.app_public_inputs.insert(app.clone(), Data::empty());
+        if let Some(v) = cur_ver {
+            spell.versioned_apps.insert(app.vk.clone(), v);
+        }
+
+        let mut prev_spells = BTreeMap::new();
+        prev_spells.insert(prev_tx_id, (prev_spell, 1usize));
+        (spell, prev_spells)
+    }
+
+    #[test]
+    fn simple_transfer_version_unchanged_ok() {
+        let app = an_nft_app();
+        let (spell, prev_spells) = build_simple_nft_transfer_fixture(
+            app.clone(),
+            Some(versioned(3, HASH_A)),
+            Some(versioned(3, HASH_A)),
+        );
+        let tx = build_tx(&spell, &prev_spells);
+        // Sanity: this really is a simple transfer.
+        assert!(is_simple_transfer(&app, &tx));
+        check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &tx).unwrap();
+    }
+
+    #[test]
+    fn simple_transfer_version_bump_rejected() {
+        let app = an_nft_app();
+        // Without the simple-transfer rule, bumping from 3 -> 4 would pass (rule 2
+        // allows higher). Rule 4 rejects it: you can't upgrade via a pure transfer.
+        let (spell, prev_spells) = build_simple_nft_transfer_fixture(
+            app.clone(),
+            Some(versioned(3, HASH_A)),
+            Some(versioned(4, HASH_B)),
+        );
+        let tx = build_tx(&spell, &prev_spells);
+        assert!(is_simple_transfer(&app, &tx));
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &tx)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("simple transfers must keep the version unchanged"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn simple_transfer_drop_to_zero_rejected() {
+        let app = an_nft_app();
+        // Even though rule 2 allows moving to 0, rule 4 forbids it for simple transfers.
+        let (spell, prev_spells) = build_simple_nft_transfer_fixture(
+            app.clone(),
+            Some(versioned(5, HASH_A)),
+            Some(versioned(0, HASH_B)),
+        );
+        let tx = build_tx(&spell, &prev_spells);
+        assert!(is_simple_transfer(&app, &tx));
+        let err = check_app_version_continuity(&spell, &prev_spells, &BTreeMap::new(), &tx)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("simple transfers must keep the version unchanged"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/charms-client/src/request.rs
+++ b/charms-client/src/request.rs
@@ -2,7 +2,7 @@ use crate::{
     BeamSource, NormalizedSpell,
     tx::{Chain, Tx},
 };
-use charms_data::{App, B32, Data, UtxoId, util};
+use charms_data::{App, AppSignature, B32, Data, UtxoId, util};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, IfIsHumanReadable, base64::Base64, serde_as};
 use std::collections::BTreeMap;
@@ -58,6 +58,11 @@ pub struct ProveRequest {
     #[serde_as(as = "IfIsHumanReadable<BTreeMap<DisplayFromStr, Base64>>")]
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub binaries: BTreeMap<B32, Vec<u8>>,
+    /// Signatures over Wasm binary hashes, for versioned app modules. Keyed by app `vk`
+    /// (which is the SHA256 of the signing public key).
+    #[serde_as(as = "IfIsHumanReadable<BTreeMap<DisplayFromStr, _>>")]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub app_signatures: BTreeMap<B32, AppSignature>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub prev_txs: Vec<Tx>,
     pub change_address: String,

--- a/charms-data/src/lib.rs
+++ b/charms-data/src/lib.rs
@@ -788,4 +788,36 @@ mod tests {
 pub struct AppInput {
     pub app_binaries: BTreeMap<B32, Vec<u8>>,
     pub app_private_inputs: BTreeMap<App, Data>,
+    /// Signatures of Wasm binary hashes for versioned app modules, keyed by app `vk` (which is
+    /// the SHA256 of the signing public key).
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub app_signatures: BTreeMap<B32, AppSignature>,
+}
+
+/// Identifies a specific version of an app's Wasm binary, signed by the app's owning key.
+///
+/// For a versioned app, the app's `vk` is the SHA256 of a public key. The corresponding
+/// [`AppSignature`] proves that the holder of that key has authorized this particular Wasm
+/// binary as the given `version` of the app.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionedApp {
+    /// Version number, as exposed by the `__charms_version` export of the Wasm binary.
+    pub version: u32,
+    /// SHA256 hash of the Wasm binary that implements this version of the app.
+    pub wasm_hash: B32,
+}
+
+/// Signature on a Wasm binary hash, together with the x-only public key it was produced with.
+///
+/// The signature scheme is BIP-340 Schnorr over secp256k1. `public_key` is the 32-byte x-only
+/// verifying key (BIP-340); `signature` is the 64-byte Schnorr signature over the SHA256 hash
+/// of the Wasm binary (i.e. over the corresponding [`VersionedApp::wasm_hash`]).
+#[serde_as]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppSignature {
+    /// BIP-340 x-only public key (32 bytes).
+    pub public_key: B32,
+    /// BIP-340 Schnorr signature over the Wasm binary's SHA256 hash (64 bytes).
+    #[serde_as(as = "IfIsHumanReadable<Hex>")]
+    pub signature: Vec<u8>,
 }

--- a/charms-data/src/lib.rs
+++ b/charms-data/src/lib.rs
@@ -801,7 +801,7 @@ pub struct AppInput {
 /// binary as the given `version` of the app.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VersionedApp {
-    /// Version number, as exposed by the `__charms_version` export of the Wasm binary.
+    /// Version number, as exposed by the `__app_version` export of the Wasm binary.
     pub version: u32,
     /// SHA256 hash of the Wasm binary that implements this version of the app.
     pub wasm_hash: B32,

--- a/charms-data/src/lib.rs
+++ b/charms-data/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{
     de::{DeserializeOwned, SeqAccess, Visitor},
     ser::SerializeTuple,
 };
-use serde_with::{IfIsHumanReadable, hex::Hex, serde_as};
+use serde_with::{Bytes, IfIsHumanReadable, hex::Hex, serde_as};
 pub mod util;
 
 /// Macro to check a condition and return false (early) if it does not hold.
@@ -811,13 +811,15 @@ pub struct VersionedApp {
 ///
 /// The signature scheme is BIP-340 Schnorr over secp256k1. `public_key` is the 32-byte x-only
 /// verifying key (BIP-340); `signature` is the 64-byte Schnorr signature over the SHA256 hash
-/// of the Wasm binary (i.e. over the corresponding [`VersionedApp::wasm_hash`]).
+/// of the Wasm binary (i.e. over the corresponding [`VersionedApp::wasm_hash`]). Both fields
+/// are typed as fixed-size byte arrays so that bad lengths are rejected at the
+/// (de)serialization boundary rather than deep inside signature verification.
 #[serde_as]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppSignature {
     /// BIP-340 x-only public key (32 bytes).
     pub public_key: B32,
     /// BIP-340 Schnorr signature over the Wasm binary's SHA256 hash (64 bytes).
-    #[serde_as(as = "IfIsHumanReadable<Hex>")]
-    pub signature: Vec<u8>,
+    #[serde_as(as = "IfIsHumanReadable<Hex, Bytes>")]
+    pub signature: [u8; 64],
 }

--- a/charms-sdk/src/lib.rs
+++ b/charms-sdk/src/lib.rs
@@ -18,11 +18,15 @@ macro_rules! main {
 ///
 /// Expands to:
 /// - `pub const VERSION: u32 = $version;` for use in the app's Rust code, and
-/// - a `#[no_mangle] extern "C" fn __app_version() -> u32` export so the version is readable from
-///   the compiled Wasm binary.
+/// - a `#[unsafe(no_mangle)] extern "C" fn __app_version() -> u32` export so the version
+///   is readable from the compiled Wasm binary.
 ///
 /// Use exactly once at the top of an app's `lib.rs`/`main.rs`. Spell prove and check will
-/// verify that this value matches the `version` declared in [`NormalizedSpell::versioned_apps`].
+/// verify that this value matches the `version` declared in `NormalizedSpell::versioned_apps`.
+///
+/// **Edition requirement:** the expansion uses the Rust 2024 spelling
+/// `#[unsafe(no_mangle)]`, which means the consuming crate must be on edition 2024 (or
+/// later). The official `charms-app` template already sets `edition = "2024"`.
 ///
 /// ```ignore
 /// charms_sdk::app_version!(1);

--- a/charms-sdk/src/lib.rs
+++ b/charms-sdk/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! main {
 ///
 /// Expands to:
 /// - `pub const VERSION: u32 = $version;` for use in the app's Rust code, and
-/// - a `#[no_mangle] extern "C" fn __charms_version() -> u32` export so the version is
+/// - a `#[no_mangle] extern "C" fn __app_version() -> u32` export so the version is
 ///   readable from the compiled Wasm binary.
 ///
 /// Use exactly once at the top of an app's `lib.rs`/`main.rs`. Spell prove and check will
@@ -32,7 +32,7 @@ macro_rules! app_version {
     ($version:expr) => {
         pub const VERSION: u32 = $version;
         #[unsafe(no_mangle)]
-        pub extern "C" fn __charms_version() -> u32 {
+        pub extern "C" fn __app_version() -> u32 {
             VERSION
         }
     };

--- a/charms-sdk/src/lib.rs
+++ b/charms-sdk/src/lib.rs
@@ -18,8 +18,8 @@ macro_rules! main {
 ///
 /// Expands to:
 /// - `pub const VERSION: u32 = $version;` for use in the app's Rust code, and
-/// - a `#[no_mangle] extern "C" fn __app_version() -> u32` export so the version is
-///   readable from the compiled Wasm binary.
+/// - a `#[no_mangle] extern "C" fn __app_version() -> u32` export so the version is readable from
+///   the compiled Wasm binary.
 ///
 /// Use exactly once at the top of an app's `lib.rs`/`main.rs`. Spell prove and check will
 /// verify that this value matches the `version` declared in [`NormalizedSpell::versioned_apps`].

--- a/charms-sdk/src/lib.rs
+++ b/charms-sdk/src/lib.rs
@@ -13,3 +13,27 @@ macro_rules! main {
         }
     };
 }
+
+/// Declare the version of a versioned Charms app module.
+///
+/// Expands to:
+/// - `pub const VERSION: u32 = $version;` for use in the app's Rust code, and
+/// - a `#[no_mangle] extern "C" fn __charms_version() -> u32` export so the version is
+///   readable from the compiled Wasm binary.
+///
+/// Use exactly once at the top of an app's `lib.rs`/`main.rs`. Spell prove and check will
+/// verify that this value matches the `version` declared in [`NormalizedSpell::versioned_apps`].
+///
+/// ```ignore
+/// charms_sdk::app_version!(1);
+/// ```
+#[macro_export]
+macro_rules! app_version {
+    ($version:expr) => {
+        pub const VERSION: u32 = $version;
+        #[unsafe(no_mangle)]
+        pub extern "C" fn __charms_version() -> u32 {
+            VERSION
+        }
+    };
+}

--- a/charms-spell-checker/Cargo.lock
+++ b/charms-spell-checker/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "anyhow",
  "charms-data",
  "rand 0.10.1",
+ "secp256k1 0.29.1",
  "sha2 0.10.9",
  "wasmi",
 ]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1,11 +1,13 @@
-use anyhow::{Result, anyhow, ensure};
+use anyhow::{Context, Result, anyhow, ensure};
 use charms_app_runner::AppRunner;
-use charms_data::B32;
+use charms_data::{AppSignature, B32};
+use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
     collections::BTreeMap,
     fs, io,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 
@@ -63,16 +65,23 @@ pub fn build() -> Result<()> {
     Ok(())
 }
 
-pub fn vk(path: Option<PathBuf>) -> Result<()> {
-    let binary = match path {
-        Some(path) => fs::read(path)?,
+pub fn vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<()> {
+    let vk = match pubkey {
+        Some(pubkey_path) => {
+            let pk_bytes = read_public_key(&pubkey_path)?;
+            B32(Sha256::digest(&pk_bytes).into())
+        }
         None => {
-            let bin_path = do_build()?;
-            fs::read(bin_path)?
+            let binary = match path {
+                Some(path) => fs::read(path)?,
+                None => {
+                    let bin_path = do_build()?;
+                    fs::read(bin_path)?
+                }
+            };
+            B32(Sha256::digest(&binary).into())
         }
     };
-    let hash = Sha256::digest(binary);
-    let vk = B32(hash.into());
 
     println!("{}", vk);
     Ok(())
@@ -92,4 +101,116 @@ pub fn binaries_by_vk(
         })
         .collect::<Result<_>>()?;
     Ok(binaries)
+}
+
+/// JSON-serializable BIP-340 Schnorr keypair, written by `app keygen` and read by `app sign`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppKeypair {
+    /// Hex-encoded 32-byte BIP-340 x-only public key.
+    pub public_key: String,
+    /// Hex-encoded 32-byte secp256k1 secret key.
+    pub secret_key: String,
+    /// Hex-encoded 32-byte VK (SHA-256 of `public_key`).
+    pub vk: String,
+}
+
+pub fn keygen(out: Option<PathBuf>) -> Result<()> {
+    let secp = Secp256k1::new();
+    let (secret_key, public_key_bytes) = loop {
+        let mut seed = [0u8; 32];
+        getrandom::getrandom(&mut seed).context("failed to obtain OS randomness")?;
+        let Ok(sk) = SecretKey::from_slice(&seed) else {
+            continue;
+        };
+        let keypair = Keypair::from_secret_key(&secp, &sk);
+        let (xonly, _parity) = keypair.x_only_public_key();
+        break (sk, xonly.serialize());
+    };
+    let vk = Sha256::digest(&public_key_bytes);
+
+    let keypair = AppKeypair {
+        public_key: hex::encode(public_key_bytes),
+        secret_key: hex::encode(secret_key.secret_bytes()),
+        vk: hex::encode(vk),
+    };
+
+    let s = serde_json::to_string_pretty(&keypair)?;
+    match out {
+        Some(p) => fs::write(p, s.as_bytes())?,
+        None => println!("{}", s),
+    }
+    Ok(())
+}
+
+pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<()> {
+    let secp = Secp256k1::new();
+    let keypair = load_keypair(&secp, &key)?;
+    let (xonly_pk, _parity) = keypair.x_only_public_key();
+
+    let binary = match bin {
+        Some(p) => fs::read(p)?,
+        None => fs::read(do_build()?)?,
+    };
+    let binary_hash: [u8; 32] = Sha256::digest(&binary).into();
+    let msg = Message::from_digest(binary_hash);
+    let signature = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
+
+    let app_sig = AppSignature {
+        public_key: B32(xonly_pk.serialize()),
+        signature: signature.as_ref().to_vec(),
+    };
+    let s = serde_json::to_string_pretty(&app_sig)?;
+    match out {
+        Some(p) => fs::write(p, s.as_bytes())?,
+        None => println!("{}", s),
+    }
+    Ok(())
+}
+
+fn load_keypair<C: secp256k1::Signing>(
+    secp: &Secp256k1<C>,
+    path: &Path,
+) -> Result<Keypair> {
+    let s = fs::read_to_string(path)
+        .with_context(|| format!("failed to read keypair file: {}", path.display()))?;
+    let kp: AppKeypair = serde_json::from_str(&s)
+        .with_context(|| format!("failed to parse keypair JSON: {}", path.display()))?;
+    let secret_bytes = hex::decode(&kp.secret_key).context("invalid hex in secret_key")?;
+    let sk = SecretKey::from_slice(&secret_bytes)
+        .map_err(|e| anyhow!("invalid secp256k1 secret key: {}", e))?;
+    Ok(Keypair::from_secret_key(secp, &sk))
+}
+
+fn read_public_key(path: &Path) -> Result<[u8; 32]> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read public key file: {}", path.display()))?;
+    // Accept either: raw 32 bytes; a hex string (64 chars); or an AppKeypair JSON.
+    if bytes.len() == 32 {
+        return Ok(bytes.as_slice().try_into().unwrap());
+    }
+    if let Ok(s) = std::str::from_utf8(&bytes) {
+        let s = s.trim();
+        if s.starts_with('{') {
+            let kp: AppKeypair = serde_json::from_str(s)?;
+            let pk = hex::decode(&kp.public_key)?;
+            return pk
+                .try_into()
+                .map_err(|_| anyhow!("public_key must be 32 bytes"));
+        }
+        let pk = hex::decode(s.trim_start_matches("0x")).context("invalid hex public key")?;
+        return pk
+            .try_into()
+            .map_err(|_| anyhow!("public key must be 32 bytes"));
+    }
+    Err(anyhow!(
+        "unrecognized public key file format: expected raw 32 bytes, hex, or AppKeypair JSON"
+    ))
+}
+
+pub fn read_app_signatures(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("failed to read app signatures file: {}", path.display()))?;
+    let map: BTreeMap<B32, AppSignature> = serde_yaml::from_slice(&bytes)
+        .with_context(|| format!("failed to parse app signatures: {}", path.display()))?;
+    Ok(map)
 }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -109,11 +109,18 @@ pub fn binaries_by_vk(
 }
 
 /// JSON-serializable BIP-340 Schnorr keypair, written by `app keygen` and read by `app sign`.
+///
+/// `secret_key` is the raw 32-byte secp256k1 secret scalar (not a BIP-340 "tweaked"
+/// secret). It's paired with `Keypair::from_secret_key`, whose `.x_only_public_key()`
+/// derivation produces `public_key`. Any third-party tool that interprets `secret_key`
+/// differently and produces a different x-only public key will be rejected by
+/// `load_keypair`, which re-derives `public_key` and `vk` from `secret_key` and
+/// requires both to match what's on disk.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppKeypair {
-    /// Hex-encoded 32-byte BIP-340 x-only public key.
+    /// Hex-encoded 32-byte BIP-340 x-only public key (derived from `secret_key`).
     pub public_key: String,
-    /// Hex-encoded 32-byte secp256k1 secret key.
+    /// Hex-encoded 32-byte raw secp256k1 secret scalar.
     pub secret_key: String,
     /// Hex-encoded 32-byte VK (SHA-256 of `public_key`).
     pub vk: String,

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -167,10 +167,7 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
     Ok(())
 }
 
-fn load_keypair<C: secp256k1::Signing>(
-    secp: &Secp256k1<C>,
-    path: &Path,
-) -> Result<Keypair> {
+fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Result<Keypair> {
     let s = fs::read_to_string(path)
         .with_context(|| format!("failed to read keypair file: {}", path.display()))?;
     let kp: AppKeypair = serde_json::from_str(&s)

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -66,6 +66,11 @@ pub fn build() -> Result<()> {
 }
 
 pub fn vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<()> {
+    ensure!(
+        !(path.is_some() && pubkey.is_some()),
+        "pass at most one of <PATH> or --pubkey: <PATH> computes SHA-256 of a Wasm binary \
+         (simple app VK), --pubkey computes SHA-256 of a signing public key (versioned app VK)"
+    );
     let vk = match pubkey {
         Some(pubkey_path) => {
             let pk_bytes = read_public_key(&pubkey_path)?;
@@ -136,9 +141,39 @@ pub fn keygen(out: Option<PathBuf>) -> Result<()> {
 
     let s = serde_json::to_string_pretty(&keypair)?;
     match out {
-        Some(p) => fs::write(p, s.as_bytes())?,
-        None => println!("{}", s),
+        Some(p) => write_secret_file(&p, s.as_bytes())?,
+        None => {
+            eprintln!(
+                "WARNING: writing the secret key to stdout. Capture it directly (e.g. \
+                 `... > key.json`) and protect the file; do not paste into chats or logs. \
+                 Prefer `--out <FILE>` (which writes with mode 0600 on Unix)."
+            );
+            println!("{}", s);
+        }
     }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("failed to open {} for writing", path.display()))?;
+    use std::io::Write as _;
+    file.write_all(contents)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
+    fs::write(path, contents)
+        .with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -153,7 +188,12 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
     };
     let binary_hash: [u8; 32] = Sha256::digest(&binary).into();
     let msg = Message::from_digest(binary_hash);
-    let signature = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
+
+    // BIP-340 recommends fresh auxiliary randomness for each signature to defend
+    // against fault attacks; pull 32 bytes from the OS.
+    let mut aux_rand = [0u8; 32];
+    getrandom::getrandom(&mut aux_rand).context("failed to obtain OS randomness")?;
+    let signature = secp.sign_schnorr_with_aux_rand(&msg, &keypair, &aux_rand);
 
     let app_sig = AppSignature {
         public_key: B32(xonly_pk.serialize()),
@@ -167,6 +207,9 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
     Ok(())
 }
 
+/// Load a keypair, deriving the verifying key from the on-disk secret key and rejecting
+/// inconsistent `public_key` / `vk` fields. Catches accidental edits or swaps in the file
+/// before any signed material is produced.
 fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Result<Keypair> {
     let s = fs::read_to_string(path)
         .with_context(|| format!("failed to read keypair file: {}", path.display()))?;
@@ -175,33 +218,53 @@ fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Resu
     let secret_bytes = hex::decode(&kp.secret_key).context("invalid hex in secret_key")?;
     let sk = SecretKey::from_slice(&secret_bytes)
         .map_err(|e| anyhow!("invalid secp256k1 secret key: {}", e))?;
-    Ok(Keypair::from_secret_key(secp, &sk))
+    let keypair = Keypair::from_secret_key(secp, &sk);
+
+    let (derived_xonly, _parity) = keypair.x_only_public_key();
+    let derived_pk = derived_xonly.serialize();
+    let declared_pk = hex::decode(&kp.public_key).context("invalid hex in public_key")?;
+    ensure!(
+        declared_pk.as_slice() == derived_pk.as_slice(),
+        "keypair file is corrupt: public_key does not match the x-only public key derived \
+         from secret_key (declared {}, derived {})",
+        kp.public_key,
+        hex::encode(derived_pk)
+    );
+
+    let derived_vk: [u8; 32] = Sha256::digest(&derived_pk).into();
+    let declared_vk = hex::decode(&kp.vk).context("invalid hex in vk")?;
+    ensure!(
+        declared_vk.as_slice() == &derived_vk,
+        "keypair file is corrupt: vk does not match SHA-256 of public_key \
+         (declared {}, derived {})",
+        kp.vk,
+        hex::encode(derived_vk)
+    );
+
+    Ok(keypair)
 }
 
+/// Read a BIP-340 x-only public key from `path`. Accepts either:
+/// - a hex string (with optional `0x` prefix), or
+/// - an [`AppKeypair`] JSON document (the file produced by `app keygen`).
+///
+/// Raw binary input is rejected to avoid ambiguity (a 32-byte file could plausibly be a
+/// raw key, a hex string of a 16-byte key, or truncated text).
 fn read_public_key(path: &Path) -> Result<[u8; 32]> {
-    let bytes = fs::read(path)
+    let s = fs::read_to_string(path)
         .with_context(|| format!("failed to read public key file: {}", path.display()))?;
-    // Accept either: raw 32 bytes; a hex string (64 chars); or an AppKeypair JSON.
-    if bytes.len() == 32 {
-        return Ok(bytes.as_slice().try_into().unwrap());
-    }
-    if let Ok(s) = std::str::from_utf8(&bytes) {
-        let s = s.trim();
-        if s.starts_with('{') {
-            let kp: AppKeypair = serde_json::from_str(s)?;
-            let pk = hex::decode(&kp.public_key)?;
-            return pk
-                .try_into()
-                .map_err(|_| anyhow!("public_key must be 32 bytes"));
-        }
-        let pk = hex::decode(s.trim_start_matches("0x")).context("invalid hex public key")?;
-        return pk
-            .try_into()
-            .map_err(|_| anyhow!("public key must be 32 bytes"));
-    }
-    Err(anyhow!(
-        "unrecognized public key file format: expected raw 32 bytes, hex, or AppKeypair JSON"
-    ))
+    let s = s.trim();
+    let pk_hex = if s.starts_with('{') {
+        let kp: AppKeypair = serde_json::from_str(s).with_context(|| {
+            format!("failed to parse keypair JSON: {}", path.display())
+        })?;
+        kp.public_key
+    } else {
+        s.trim_start_matches("0x").to_string()
+    };
+    let pk = hex::decode(&pk_hex).context("invalid hex public key")?;
+    pk.try_into()
+        .map_err(|_| anyhow!("public key must be 32 bytes (hex-encoded as 64 characters)"))
 }
 
 pub fn read_app_signatures(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -204,7 +204,7 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
 
     let app_sig = AppSignature {
         public_key: B32(xonly_pk.serialize()),
-        signature: signature.as_ref().to_vec(),
+        signature: *signature.as_ref(),
     };
     let s = serde_json::to_string_pretty(&app_sig)?;
     match out {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -180,6 +180,12 @@ pub struct SpellProveParams {
     #[arg(long)]
     app_bins: Vec<PathBuf>,
 
+    /// Path to a YAML/JSON file mapping a versioned app's `vk` (hex) to its
+    /// `{public_key, signature}` (hex). Required for versioned apps; omitted for simple
+    /// (immutable) apps.
+    #[arg(long)]
+    app_signatures: Option<PathBuf>,
+
     /// Bitcoin or Cardano address to send the change to.
     #[arg(long)]
     change_address: String,
@@ -218,6 +224,12 @@ pub struct SpellCheckParams {
     /// Paths to app Wasm binaries (.wasm files).
     #[arg(long)]
     app_bins: Vec<PathBuf>,
+
+    /// Path to a YAML/JSON file mapping a versioned app's `vk` (hex) to its
+    /// `{public_key, signature}` (hex). Required for versioned apps; omitted for simple
+    /// (immutable) apps.
+    #[arg(long)]
+    app_signatures: Option<PathBuf>,
 
     /// Hex-encoded pre-requisite transactions.
     /// Must include the transactions that create the UTXOs spent by the spell.
@@ -338,12 +350,47 @@ pub enum AppCommands {
     /// Prints the path to the built .wasm binary to stdout.
     Build,
 
-    /// Show verification key (SHA-256 of Wasm binary) for an app.
+    /// Show verification key (VK) for an app.
     ///
+    /// For a simple (immutable) app the VK is SHA-256 of the Wasm binary.
+    /// For a versioned app, pass `--pubkey` to compute SHA-256 of the signing public key.
     /// Prints the hex-encoded VK to stdout.
     Vk {
-        /// Path to app Wasm binary (builds the app if omitted).
+        /// Path to app Wasm binary (builds the app if omitted, ignored when --pubkey is set).
         path: Option<PathBuf>,
+
+        /// Path to a 32-byte raw Ed25519 public key (or app keypair JSON). When set, prints
+        /// the VK of the corresponding versioned app (SHA-256 of the public key).
+        #[arg(long)]
+        pubkey: Option<PathBuf>,
+    },
+
+    /// Generate a new Ed25519 signing keypair for a versioned app.
+    ///
+    /// Writes a JSON object with hex-encoded `public_key`, `secret_key`, and computed `vk`
+    /// (SHA-256 of public key) to `--out` (or stdout if omitted).
+    Keygen {
+        /// Path to write the keypair JSON to. Prints to stdout if omitted.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
+
+    /// Sign a Wasm binary's SHA-256 hash with an app signing key.
+    ///
+    /// Writes a JSON `{public_key, signature}` (hex) to `--out` (or stdout). The signature
+    /// is an Ed25519 signature over the binary's SHA-256 hash.
+    Sign {
+        /// Path to the keypair JSON produced by `app keygen`.
+        #[arg(long)]
+        key: PathBuf,
+
+        /// Path to the Wasm binary to sign (builds the app if omitted).
+        #[arg(long)]
+        bin: Option<PathBuf>,
+
+        /// Path to write the signature JSON to. Prints to stdout if omitted.
+        #[arg(long)]
+        out: Option<PathBuf>,
     },
 }
 
@@ -418,8 +465,10 @@ pub async fn run() -> anyhow::Result<()> {
         },
         Commands::App { command } => match command {
             AppCommands::New { name } => app::new(&name),
-            AppCommands::Vk { path } => app::vk(path),
+            AppCommands::Vk { path, pubkey } => app::vk(path, pubkey),
             AppCommands::Build => app::build(),
+            AppCommands::Keygen { out } => app::keygen(out),
+            AppCommands::Sign { key, bin, out } => app::sign(key, bin, out),
         },
         Commands::Wallet { command } => {
             let wallet_cli = wallet_cli();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -359,16 +359,20 @@ pub enum AppCommands {
         /// Path to app Wasm binary (builds the app if omitted, ignored when --pubkey is set).
         path: Option<PathBuf>,
 
-        /// Path to a 32-byte raw Ed25519 public key (or app keypair JSON). When set, prints
-        /// the VK of the corresponding versioned app (SHA-256 of the public key).
+        /// Path to a BIP-340 x-only public key (secp256k1) in hex, or app keypair JSON.
+        /// When set, prints the VK of the corresponding versioned app
+        /// (SHA-256 of the public key).
         #[arg(long)]
         pubkey: Option<PathBuf>,
     },
 
-    /// Generate a new Ed25519 signing keypair for a versioned app.
+    /// Generate a new BIP-340 Schnorr signing keypair (secp256k1) for a versioned app.
     ///
     /// Writes a JSON object with hex-encoded `public_key`, `secret_key`, and computed `vk`
     /// (SHA-256 of public key) to `--out` (or stdout if omitted).
+    ///
+    /// **Security:** the `secret_key` field is sensitive. Prefer `--out` to a file you
+    /// trust; do not commit it to source control or paste it into chats/logs.
     Keygen {
         /// Path to write the keypair JSON to. Prints to stdout if omitted.
         #[arg(long)]
@@ -378,7 +382,7 @@ pub enum AppCommands {
     /// Sign a Wasm binary's SHA-256 hash with an app signing key.
     ///
     /// Writes a JSON `{public_key, signature}` (hex) to `--out` (or stdout). The signature
-    /// is an Ed25519 signature over the binary's SHA-256 hash.
+    /// is a BIP-340 Schnorr signature (over secp256k1) of the binary's SHA-256 hash.
     Sign {
         /// Path to the keypair JSON produced by `app keygen`.
         #[arg(long)]

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -4,7 +4,8 @@ use crate::{
     spell::{
         NormalizedSpell, ProveRequest, ProveSpellTx, ProveSpellTxImpl, adjust_coin_contents,
         ensure_all_prev_txs_are_present, ensure_exact_app_binaries,
-        ensure_versioned_apps_have_signatures, from_strings, read_private_inputs,
+        ensure_no_orphan_versioned_apps, ensure_versioned_apps_have_signatures, from_strings,
+        read_private_inputs,
     },
 };
 use anyhow::{Result, ensure};
@@ -100,6 +101,7 @@ impl Prove for SpellCli {
             .map(|p| cli::app::read_app_signatures(&p))
             .transpose()?
             .unwrap_or_default();
+        ensure_no_orphan_versioned_apps(&norm_spell)?;
         ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
         let app_input = match binaries.is_empty() {
             true => None,
@@ -220,6 +222,7 @@ impl Check for SpellCli {
             .map(|p| cli::app::read_app_signatures(&p))
             .transpose()?
             .unwrap_or_default();
+        ensure_no_orphan_versioned_apps(&norm_spell)?;
         ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
 
         let prev_spells = charms_client::prev_spells(&prev_txs, SPELL_VK, &norm_spell)?;

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -3,8 +3,8 @@ use crate::{
     cli::{Output, SpellCheckParams, SpellProveParams},
     spell::{
         NormalizedSpell, ProveRequest, ProveSpellTx, ProveSpellTxImpl, adjust_coin_contents,
-        ensure_all_prev_txs_are_present, ensure_exact_app_binaries, from_strings,
-        read_private_inputs,
+        ensure_all_prev_txs_are_present, ensure_exact_app_binaries,
+        ensure_versioned_apps_have_signatures, from_strings, read_private_inputs,
     },
 };
 use anyhow::{Result, ensure};
@@ -13,10 +13,10 @@ use charms_client::{
     CURRENT_VERSION,
     tx::{Chain, Tx, by_txid},
 };
-use charms_data::{UtxoId, util};
+use charms_data::{AppSignature, B32, UtxoId, util};
 use charms_lib::SPELL_VK;
 use serde_json::json;
-use std::{future::Future, io::Write, str::FromStr};
+use std::{collections::BTreeMap, future::Future, io::Write, str::FromStr};
 
 pub trait Check {
     fn check(&self, params: SpellCheckParams) -> Result<()>;
@@ -65,6 +65,7 @@ impl Prove for SpellCli {
             beamed_from,
             prev_txs,
             app_bins,
+            app_signatures,
             change_address,
             fee_rate,
             chain,
@@ -95,11 +96,17 @@ impl Prove for SpellCli {
         let prev_txs = from_strings(&prev_txs)?;
 
         let binaries = cli::app::binaries_by_vk(&self.app_runner, app_bins)?;
+        let app_signatures: BTreeMap<B32, AppSignature> = app_signatures
+            .map(|p| cli::app::read_app_signatures(&p))
+            .transpose()?
+            .unwrap_or_default();
+        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
         let app_input = match binaries.is_empty() {
             true => None,
             false => Some(charms_data::AppInput {
                 app_binaries: binaries.clone(),
                 app_private_inputs: app_private_inputs.clone(),
+                app_signatures: app_signatures.clone(),
             }),
         };
 
@@ -108,6 +115,7 @@ impl Prove for SpellCli {
             app_private_inputs,
             tx_ins_beamed_source_utxos,
             binaries,
+            app_signatures,
             prev_txs,
             change_address,
             fee_rate,
@@ -178,6 +186,7 @@ impl Check for SpellCli {
             private_inputs,
             beamed_from,
             app_bins,
+            app_signatures,
             prev_txs,
             chain,
             mock,
@@ -207,6 +216,11 @@ impl Check for SpellCli {
         )?;
 
         let binaries = cli::app::binaries_by_vk(&self.app_runner, app_bins)?;
+        let app_signatures: BTreeMap<B32, AppSignature> = app_signatures
+            .map(|p| cli::app::read_app_signatures(&p))
+            .transpose()?
+            .unwrap_or_default();
+        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
 
         let prev_spells = charms_client::prev_spells(&prev_txs, SPELL_VK, &norm_spell)?;
 
@@ -224,6 +238,7 @@ impl Check for SpellCli {
             false => Some(charms_data::AppInput {
                 app_binaries: binaries.clone(),
                 app_private_inputs: app_private_inputs.clone(),
+                app_signatures: app_signatures.clone(),
             }),
         };
 
@@ -240,6 +255,8 @@ impl Check for SpellCli {
 
         let cycles_spent = self.app_runner.run_all(
             &binaries,
+            &norm_spell.versioned_apps,
+            &app_signatures,
             &charms_tx,
             &norm_spell.app_public_inputs,
             &app_private_inputs,

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -102,8 +102,11 @@ impl Prove for SpellCli {
             .transpose()?
             .unwrap_or_default();
         ensure_no_orphan_versioned_apps(&norm_spell)?;
-        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
-        let app_input = match binaries.is_empty() {
+        // Note: `ensure_versioned_apps_have_signatures` needs the resolved tx (to know
+        // which apps are simple transfers and thus skip the signature requirement). The
+        // server-side `validate_prove_request` runs that check authoritatively; we don't
+        // duplicate it here because building the tx requires loading prev spells.
+        let app_input = match binaries.is_empty() && app_signatures.is_empty() {
             true => None,
             false => Some(charms_data::AppInput {
                 app_binaries: binaries.clone(),
@@ -223,7 +226,6 @@ impl Check for SpellCli {
             .transpose()?
             .unwrap_or_default();
         ensure_no_orphan_versioned_apps(&norm_spell)?;
-        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
 
         let prev_spells = charms_client::prev_spells(&prev_txs, SPELL_VK, &norm_spell)?;
 
@@ -235,8 +237,14 @@ impl Check for SpellCli {
         );
 
         ensure_exact_app_binaries(&norm_spell, &app_private_inputs, &charms_tx, &binaries)?;
+        ensure_versioned_apps_have_signatures(
+            &norm_spell,
+            &app_private_inputs,
+            &charms_tx,
+            &app_signatures,
+        )?;
 
-        let app_input = match binaries.is_empty() {
+        let app_input = match binaries.is_empty() && app_signatures.is_empty() {
             true => None,
             false => Some(charms_data::AppInput {
                 app_binaries: binaries.clone(),

--- a/src/spell/mod.rs
+++ b/src/spell/mod.rs
@@ -10,11 +10,12 @@ pub use prove_spell_tx::{ProveSpellTx, ProveSpellTxImpl, committed_data_hash};
 pub use request::{CharmsFee, FeeAddressForNetwork, ProveRequest};
 pub use validate::{
     adjust_coin_contents, ensure_all_prev_txs_are_present, ensure_exact_app_binaries,
-    ensure_no_orphan_versioned_apps, ensure_versioned_apps_have_signatures,
+    ensure_versioned_apps_have_signatures,
 };
 
 pub use charms_client::{
-    BeamSource, CURRENT_VERSION, NormalizedCharms, NormalizedSpell, Proof, SpellProverInput, to_tx,
+    BeamSource, CURRENT_VERSION, NormalizedCharms, NormalizedSpell, Proof, SpellProverInput,
+    ensure_no_orphan_versioned_apps, to_tx,
     tx::{Chain, Tx},
 };
 

--- a/src/spell/mod.rs
+++ b/src/spell/mod.rs
@@ -10,7 +10,7 @@ pub use prove_spell_tx::{ProveSpellTx, ProveSpellTxImpl, committed_data_hash};
 pub use request::{CharmsFee, FeeAddressForNetwork, ProveRequest};
 pub use validate::{
     adjust_coin_contents, ensure_all_prev_txs_are_present, ensure_exact_app_binaries,
-    ensure_versioned_apps_have_signatures,
+    ensure_no_orphan_versioned_apps, ensure_versioned_apps_have_signatures,
 };
 
 pub use charms_client::{

--- a/src/spell/mod.rs
+++ b/src/spell/mod.rs
@@ -10,6 +10,7 @@ pub use prove_spell_tx::{ProveSpellTx, ProveSpellTxImpl, committed_data_hash};
 pub use request::{CharmsFee, FeeAddressForNetwork, ProveRequest};
 pub use validate::{
     adjust_coin_contents, ensure_all_prev_txs_are_present, ensure_exact_app_binaries,
+    ensure_versioned_apps_have_signatures,
 };
 
 pub use charms_client::{

--- a/src/spell/prove.rs
+++ b/src/spell/prove.rs
@@ -19,7 +19,7 @@ use ark_std::{
     test_rng,
 };
 use charms_client::{BeamSource, MOCK_SPELL_VK, NormalizedSpell, Proof, SpellProverInput};
-use charms_data::{App, AppInput, B32, Data, util};
+use charms_data::{App, AppInput, AppSignature, B32, Data, util};
 use charms_lib::SPELL_VK;
 use sha2::{Digest, Sha256};
 use sp1_prover::HashableKey;
@@ -72,6 +72,7 @@ pub trait Prove: Send + Sync {
         &self,
         norm_spell: NormalizedSpell,
         app_binaries: BTreeMap<B32, Vec<u8>>,
+        app_signatures: BTreeMap<B32, AppSignature>,
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
@@ -107,6 +108,7 @@ impl Prove for Prover {
         &self,
         norm_spell: NormalizedSpell,
         app_binaries: BTreeMap<B32, Vec<u8>>,
+        app_signatures: BTreeMap<B32, AppSignature>,
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
@@ -121,6 +123,7 @@ impl Prove for Prover {
             false => Some(AppInput {
                 app_binaries,
                 app_private_inputs,
+                app_signatures,
             }),
         };
 
@@ -171,6 +174,7 @@ impl Prove for MockProver {
         &self,
         norm_spell: NormalizedSpell,
         app_binaries: BTreeMap<B32, Vec<u8>>,
+        app_signatures: BTreeMap<B32, AppSignature>,
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
@@ -182,6 +186,7 @@ impl Prove for MockProver {
             false => Some(AppInput {
                 app_binaries,
                 app_private_inputs,
+                app_signatures,
             }),
         };
 

--- a/src/spell/prove_spell_tx.rs
+++ b/src/spell/prove_spell_tx.rs
@@ -90,6 +90,7 @@ impl ProveSpellTxImpl {
             app_private_inputs,
             tx_ins_beamed_source_utxos,
             binaries,
+            app_signatures,
             prev_txs,
             change_address,
             fee_rate,
@@ -106,6 +107,7 @@ impl ProveSpellTxImpl {
         let (truncated_norm_spell, proof, proof_app_cycles) = self.prover.prove(
             norm_spell.clone(),
             binaries,
+            app_signatures,
             app_private_inputs,
             prev_txs,
             tx_ins_beamed_source_utxos,

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -76,7 +76,11 @@ pub fn ensure_versioned_apps_have_signatures(
         provided_vks
     );
     // Each versioned_apps entry must correspond to at least one referenced app.
-    let app_vks: BTreeSet<&B32> = norm_spell.app_public_inputs.keys().map(|app| &app.vk).collect();
+    let app_vks: BTreeSet<&B32> = norm_spell
+        .app_public_inputs
+        .keys()
+        .map(|app| &app.vk)
+        .collect();
     for vk in norm_spell.versioned_apps.keys() {
         ensure!(
             app_vks.contains(vk),
@@ -374,9 +378,7 @@ impl ProveSpellTxImpl {
                 let total_sats_required = total_sats_out
                     .checked_add(charms_fee)
                     .and_then(|s| s.checked_add(estimated_bitcoin_fee))
-                    .ok_or_else(|| {
-                        anyhow!("total required sats (outputs + fees) overflow u64")
-                    })?;
+                    .ok_or_else(|| anyhow!("total required sats (outputs + fees) overflow u64"))?;
 
                 ensure!(
                     total_sats_in > total_sats_required,

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -8,7 +8,7 @@ use charms_client::{
     cardano_tx::OutputContent,
     tx::{Chain, Tx, by_txid},
 };
-use charms_data::{App, AppInput, B32, Data, TxId, util};
+use charms_data::{App, AppInput, AppSignature, B32, Data, TxId, util};
 use charms_lib::SPELL_VK;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -23,7 +23,7 @@ pub fn ensure_exact_app_binaries(
     tx: &charms_data::Transaction,
     binaries: &BTreeMap<B32, Vec<u8>>,
 ) -> anyhow::Result<()> {
-    let required_vks: BTreeSet<_> = norm_spell
+    let required_binary_hashes: BTreeSet<B32> = norm_spell
         .app_public_inputs
         .iter()
         .filter(|(app, data)| {
@@ -33,20 +33,57 @@ pub fn ensure_exact_app_binaries(
                     .is_none_or(|data| data.is_empty())
                 || !charms_data::is_simple_transfer(app, tx)
         })
-        .map(|(app, _)| &app.vk)
+        .map(|(app, _)| match norm_spell.versioned_apps.get(&app.vk) {
+            Some(va) => va.wasm_hash.clone(),
+            None => app.vk.clone(),
+        })
         .collect();
 
-    let provided_vks: BTreeSet<_> = binaries.keys().collect();
+    let provided_binary_hashes: BTreeSet<B32> = binaries.keys().cloned().collect();
 
     ensure!(
-        required_vks == provided_vks,
+        required_binary_hashes == provided_binary_hashes,
         "binaries must contain exactly the required app binaries.\n\
-         Required VKs: {:?}\n\
-         Provided VKs: {:?}",
+         Required binary hashes: {:?}\n\
+         Provided binary hashes: {:?}",
+        required_binary_hashes,
+        provided_binary_hashes
+    );
+
+    Ok(())
+}
+
+/// For every versioned app referenced in the spell (whose `vk` appears in
+/// [`NormalizedSpell::versioned_apps`]), `app_signatures` must provide a matching
+/// [`AppSignature`]. Conversely, no extraneous signatures may be present.
+pub fn ensure_versioned_apps_have_signatures(
+    norm_spell: &NormalizedSpell,
+    app_signatures: &BTreeMap<B32, AppSignature>,
+) -> anyhow::Result<()> {
+    let required_vks: BTreeSet<&B32> = norm_spell
+        .app_public_inputs
+        .keys()
+        .filter(|app| norm_spell.versioned_apps.contains_key(&app.vk))
+        .map(|app| &app.vk)
+        .collect();
+    let provided_vks: BTreeSet<&B32> = app_signatures.keys().collect();
+    ensure!(
+        required_vks == provided_vks,
+        "app_signatures must contain exactly one entry per versioned app referenced in the spell.\n\
+         Required app vks: {:?}\n\
+         Provided app vks: {:?}",
         required_vks,
         provided_vks
     );
-
+    // Each versioned_apps entry must correspond to at least one referenced app.
+    let app_vks: BTreeSet<&B32> = norm_spell.app_public_inputs.keys().map(|app| &app.vk).collect();
+    for vk in norm_spell.versioned_apps.keys() {
+        ensure!(
+            app_vks.contains(vk),
+            "versioned_apps contains unused vk: {}",
+            vk
+        );
+    }
     Ok(())
 }
 
@@ -215,11 +252,15 @@ impl ProveSpellTxImpl {
             &prove_request.binaries,
         )?;
 
+        let app_signatures = prove_request.app_signatures.clone();
+        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
+
         let app_input = match prove_request.binaries.is_empty() {
             true => None,
             false => Some(AppInput {
                 app_binaries: prove_request.binaries.clone(),
                 app_private_inputs: app_private_inputs.clone(),
+                app_signatures: app_signatures.clone(),
             }),
         };
 
@@ -238,6 +279,8 @@ impl ProveSpellTxImpl {
         let total_cycles = if let Some(app_input) = &app_input {
             let cycles = AppRunner::new(true).run_all(
                 &app_input.app_binaries,
+                &norm_spell.versioned_apps,
+                &app_input.app_signatures,
                 &tx,
                 &norm_spell.app_public_inputs,
                 &app_input.app_private_inputs,

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -6,6 +6,7 @@ use charms_app_runner::AppRunner;
 use charms_client::{
     BeamSource, NormalizedSpell,
     cardano_tx::OutputContent,
+    ensure_no_orphan_versioned_apps,
     tx::{Chain, Tx, by_txid},
 };
 use charms_data::{App, AppInput, AppSignature, B32, Data, TxId, util};
@@ -90,25 +91,6 @@ pub fn ensure_versioned_apps_have_signatures(
         required_vks,
         provided_vks
     );
-    Ok(())
-}
-
-/// Each entry in `norm_spell.versioned_apps` must correspond to at least one app in
-/// `app_public_inputs`. Rejects "orphan" version pins that don't bind any app referenced
-/// by the spell.
-pub fn ensure_no_orphan_versioned_apps(norm_spell: &NormalizedSpell) -> anyhow::Result<()> {
-    let app_vks: BTreeSet<&B32> = norm_spell
-        .app_public_inputs
-        .keys()
-        .map(|app| &app.vk)
-        .collect();
-    for vk in norm_spell.versioned_apps.keys() {
-        ensure!(
-            app_vks.contains(vk),
-            "versioned_apps contains unused vk: {}",
-            vk
-        );
-    }
     Ok(())
 }
 

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -75,7 +75,13 @@ pub fn ensure_versioned_apps_have_signatures(
         required_vks,
         provided_vks
     );
-    // Each versioned_apps entry must correspond to at least one referenced app.
+    Ok(())
+}
+
+/// Each entry in `norm_spell.versioned_apps` must correspond to at least one app in
+/// `app_public_inputs`. Rejects "orphan" version pins that don't bind any app referenced
+/// by the spell.
+pub fn ensure_no_orphan_versioned_apps(norm_spell: &NormalizedSpell) -> anyhow::Result<()> {
     let app_vks: BTreeSet<&B32> = norm_spell
         .app_public_inputs
         .keys()
@@ -257,6 +263,7 @@ impl ProveSpellTxImpl {
         )?;
 
         let app_signatures = prove_request.app_signatures.clone();
+        ensure_no_orphan_versioned_apps(&norm_spell)?;
         ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
 
         let app_input = match prove_request.binaries.is_empty() {

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -53,23 +53,38 @@ pub fn ensure_exact_app_binaries(
     Ok(())
 }
 
-/// For every versioned app referenced in the spell (whose `vk` appears in
-/// [`NormalizedSpell::versioned_apps`]), `app_signatures` must provide a matching
-/// [`AppSignature`]. Conversely, no extraneous signatures may be present.
+/// `app_signatures` must contain exactly one entry per **non-simple-transfer** versioned
+/// app referenced in the spell. Simple-transfer versioned apps are intentionally excluded:
+/// the spell-level continuity check pins their `(version, wasm_hash)` to whatever the
+/// previous spell already authenticated, so no fresh binary or signature is needed.
+///
+/// "Simple transfer" here matches [`charms_data::is_simple_transfer`] AND has no public or
+/// private input — exactly the condition under which [`AppRunner::run_all`] skips the
+/// binary entirely.
 pub fn ensure_versioned_apps_have_signatures(
     norm_spell: &NormalizedSpell,
+    app_private_inputs: &BTreeMap<App, Data>,
+    tx: &charms_data::Transaction,
     app_signatures: &BTreeMap<B32, AppSignature>,
 ) -> anyhow::Result<()> {
     let required_vks: BTreeSet<&B32> = norm_spell
         .app_public_inputs
-        .keys()
-        .filter(|app| norm_spell.versioned_apps.contains_key(&app.vk))
-        .map(|app| &app.vk)
+        .iter()
+        .filter(|(app, _)| norm_spell.versioned_apps.contains_key(&app.vk))
+        .filter(|(app, data)| {
+            !data.is_empty()
+                || !app_private_inputs
+                    .get(app)
+                    .is_none_or(|w| w.is_empty())
+                || !charms_data::is_simple_transfer(app, tx)
+        })
+        .map(|(app, _)| &app.vk)
         .collect();
     let provided_vks: BTreeSet<&B32> = app_signatures.keys().collect();
     ensure!(
         required_vks == provided_vks,
-        "app_signatures must contain exactly one entry per versioned app referenced in the spell.\n\
+        "app_signatures must contain exactly one entry per non-simple-transfer versioned app \
+         referenced in the spell.\n\
          Required app vks: {:?}\n\
          Provided app vks: {:?}",
         required_vks,
@@ -264,7 +279,12 @@ impl ProveSpellTxImpl {
 
         let app_signatures = prove_request.app_signatures.clone();
         ensure_no_orphan_versioned_apps(&norm_spell)?;
-        ensure_versioned_apps_have_signatures(&norm_spell, &app_signatures)?;
+        ensure_versioned_apps_have_signatures(
+            &norm_spell,
+            &app_private_inputs,
+            &tx,
+            &app_signatures,
+        )?;
 
         let app_input = match prove_request.binaries.is_empty() {
             true => None,

--- a/src/tx/cardano_tx/mod.rs
+++ b/src/tx/cardano_tx/mod.rs
@@ -19,11 +19,13 @@ use cml_core::serialization::RawBytesEncoding;
 use hex_literal::hex;
 use ic_agent::Agent;
 use pallas_codec::minicbor;
-use pallas_primitives::conway::{
-    self, BoundedBytes, ExUnits, PlutusData, PlutusScript, PostAlonzoTransactionOutput, Redeemer,
-    RedeemerTag, Redeemers, Value, WitnessSet,
+use pallas_primitives::{
+    KeepRaw,
+    conway::{
+        self, BoundedBytes, ExUnits, PlutusData, PlutusScript, PostAlonzoTransactionOutput,
+        Redeemer, RedeemerTag, Redeemers, Value, WitnessSet,
+    },
 };
-use pallas_primitives::KeepRaw;
 use pallas_txbuilder::{BuildConway, Input, Output, ScriptKind, StagingTransaction};
 use serde::{Deserialize, Serialize as SerdeSerialize};
 use std::collections::BTreeMap;
@@ -554,9 +556,7 @@ pub fn from_spell(
     // borrowing-scoped decode below).
     let total_input: u64 = spell_ins
         .iter()
-        .map(|id| {
-            with_prev_output(prev_txs_by_id, id, |o| get_output_coin(o)).unwrap_or(0)
-        })
+        .map(|id| with_prev_output(prev_txs_by_id, id, |o| get_output_coin(o)).unwrap_or(0))
         .sum();
 
     // Decode-modify-encode within a scope so the borrowed Tx<'_> lifetime is contained.
@@ -642,14 +642,13 @@ pub fn from_spell(
         // Add change output if needed
         if total_input > total_output + fee {
             let change_amount = total_input - total_output - fee;
-            let change_output = conway::TransactionOutput::PostAlonzo(KeepRaw::from(
-                PostAlonzoTransactionOutput {
+            let change_output =
+                conway::TransactionOutput::PostAlonzo(KeepRaw::from(PostAlonzoTransactionOutput {
                     address: pallas_primitives::conway::Bytes::from(change_address.to_vec()),
                     value: Value::Coin(change_amount),
                     datum_option: None,
                     script_ref: None,
-                },
-            ));
+                }));
             tx.transaction_body.outputs.push(change_output);
         }
 
@@ -739,15 +738,17 @@ fn get_output_multiasset_owned(output: &conway::TransactionOutput<'_>) -> Option
             pallas_primitives::alonzo::Value::Multiasset(_, ma) => {
                 let mut result: PallasMultiasset = BTreeMap::new();
                 for (p, assets) in ma.iter() {
-                    let inner: BTreeMap<PallasAssetName, u64> = assets
-                        .iter()
-                        .map(|(n, a)| (n.clone(), *a))
-                        .collect();
+                    let inner: BTreeMap<PallasAssetName, u64> =
+                        assets.iter().map(|(n, a)| (n.clone(), *a)).collect();
                     if !inner.is_empty() {
                         result.insert(*p, inner);
                     }
                 }
-                if result.is_empty() { None } else { Some(result) }
+                if result.is_empty() {
+                    None
+                } else {
+                    Some(result)
+                }
             }
         },
         conway::TransactionOutput::PostAlonzo(post) => match &post.value {
@@ -763,7 +764,11 @@ fn get_output_multiasset_owned(output: &conway::TransactionOutput<'_>) -> Option
                         result.insert(*p, inner);
                     }
                 }
-                if result.is_empty() { None } else { Some(result) }
+                if result.is_empty() {
+                    None
+                } else {
+                    Some(result)
+                }
             }
         },
     }


### PR DESCRIPTION
Add support for versioned Charms app modules.

For a simple (immutable) app, the app VK is its Wasm binary SHA256 hash.

For a versioned app, the app VK will be SHA256 hash of a public key (for
the app signing private key).

In `NormalizedSpell` we need to specify such VKs, their current versions
and Wasm binary hashes (SHA256).

In `ProveRequest` we need to provide signatures (and public keys) of
these Wasm binary hashes.

App module versions will be exposed via public const `VERSION: u32` in
the app Wasm modules.

For versioned app binaries, we need to check:
- the Wasm binary SHA256 hash is the one specified in the spell
- VERSION is the one specified in the spell
- the Wasm binary hash signature is correct against the provided public
  key
- the public key SHA256 equals the app VK

Make sure that when a spell spends outputs with versioned charms,
- If the app version stays the same, the app binary hash MUST stay the
  same.
- The app version in the spending spell MUST be either the same, higher
  or `0`.
- Version `0` is special: if the app version of the spent charms is `0`,
  the app version in the spending spell MUST be `0`.

Ensure that the same version of the same versioned app in all prev_txs has the same binary hash