### PR TITLE
feat(scrolls_bitcoin): delegate verify_spell to next version canister for higher spell versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "sp1-verifier-legacy",
  "strum 0.28.0",
  "test-strategy",
+ "thiserror 2.0.18",
  "tracing",
  "uplc",
 ]

--- a/charms-client/Cargo.toml
+++ b/charms-client/Cargo.toml
@@ -36,6 +36,7 @@ sp1-verifier = { workspace = true, default-features = false }
 sp1-verifier_5 = { package = "sp1-verifier", version = "5.2.4", default-features = false }
 sp1-verifier-v6_0 = { package = "sp1-verifier-legacy", version = "6.0.2" }
 strum = { version = "0.28.0", features = ["derive"] }
+thiserror = { version = "2" }
 tracing = { workspace = true }
 uplc = { version = "1.1.21" }
 

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -12,6 +12,17 @@ use sp1_primitives::io::SP1PublicValues;
 use sp1_verifier::Groth16Verifier;
 use std::collections::BTreeMap;
 use strum::{AsRefStr, EnumDiscriminants, EnumString};
+use thiserror::Error;
+
+/// Returned by [`spell_vk`] and [`groth16_vk`] when the requested spell version
+/// is not supported by this build of `charms-client`.
+///
+/// Downstream callers (e.g. ICP canisters that delegate to a newer-version
+/// canister) should detect this via `err.downcast_ref::<UnsupportedSpellVersion>()`
+/// rather than substring-matching the `Display` output.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[error("unsupported spell version: {0}")]
+pub struct UnsupportedSpellVersion(pub u32);
 
 #[enum_dispatch]
 pub trait EnchantedTx {
@@ -115,7 +126,7 @@ pub fn spell_vk(spell_version: u32, spell_vk: &str, mock: bool) -> anyhow::Resul
         V2 => Ok(V2_SPELL_VK),
         V1 => Ok(V1_SPELL_VK),
         V0 => Ok(V0_SPELL_VK),
-        _ => bail!("unsupported spell version: {}", spell_version),
+        _ => Err(UnsupportedSpellVersion(spell_version).into()),
     }
 }
 
@@ -139,7 +150,7 @@ pub fn groth16_vk(spell_version: u32, mock: bool) -> anyhow::Result<&'static [u8
         V2 => Ok(V2_GROTH16_VK_BYTES),
         V1 => Ok(V1_GROTH16_VK_BYTES),
         V0 => Ok(V0_GROTH16_VK_BYTES),
-        _ => bail!("unsupported spell version: {}", spell_version),
+        _ => Err(UnsupportedSpellVersion(spell_version).into()),
     }
 }
 
@@ -217,6 +228,24 @@ pub fn by_txid(prev_txs: &[Tx]) -> BTreeMap<TxId, Tx> {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn spell_vk_unsupported_version_typed_error() {
+        let err = spell_vk(u32::MAX, "vk", false).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<UnsupportedSpellVersion>(),
+            Some(&UnsupportedSpellVersion(u32::MAX))
+        );
+    }
+
+    #[test]
+    fn groth16_vk_unsupported_version_typed_error() {
+        let err = groth16_vk(u32::MAX, false).unwrap_err();
+        assert_eq!(
+            err.downcast_ref::<UnsupportedSpellVersion>(),
+            Some(&UnsupportedSpellVersion(u32::MAX))
+        );
+    }
 
     #[test]
     fn chain_names() {

--- a/charms-spell-checker/Cargo.lock
+++ b/charms-spell-checker/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "sp1-verifier 6.2.0",
  "sp1-verifier-legacy",
  "strum 0.28.0",
+ "thiserror 2.0.18",
  "tracing",
  "uplc",
 ]

--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "sp1-verifier 6.2.1",
  "sp1-verifier-legacy",
  "strum 0.28.0",
+ "thiserror 2.0.18",
  "tracing",
  "uplc",
 ]

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -38,7 +38,8 @@ service : () -> {
   // `seen` is the list of canister IDs already in the delegation chain (the
   // initiator plus every intermediate hop). On an `UnsupportedSpellVersion`
   // error, this canister refuses to forward to `NEXT_SCROLLS_BITCOIN_CANISTER_ID`
-  // if that ID — or this canister's own ID — already appears in `seen`,
-  // preventing A → B → A and longer cycles.
+  // if that next ID equals this canister's own ID (A → A) or already appears
+  // in `seen` (A → B → ... → A). After the checks pass, this canister appends
+  // its own ID to `seen` before calling the next hop.
   verify_spell_delegated : (text, bool, nat32, vec text) -> (Result);
 }

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -21,11 +21,24 @@ service : () -> {
   // Returns an error string on failure.
   // 
   // For higher spell versions (not supported by this canister's `charms-client`),
-  // delegates to the `verify_spell` method of the canister specified by
-  // `NEXT_SCROLLS_BITCOIN_CANISTER_ID`.
+  // delegates to the `verify_spell_delegated` method of the canister specified by
+  // `NEXT_SCROLLS_BITCOIN_CANISTER_ID`, threading the spell version and a list of
+  // already-visited canister IDs to prevent multi-hop delegation cycles.
   // 
   // The `mock` parameter controls whether mock spells are accepted:
   // - `mock = true`: accepts mock spells (for testing)
   // - `mock = false`: requires real (non-mock) spells
   verify_spell : (text, bool) -> (Result);
+  // Inter-canister entry point for delegated `verify_spell` calls.
+  // 
+  // `spell_version` is the version learned from a previous hop. If it exceeds
+  // this canister's `CURRENT_VERSION`, local verification is skipped and the
+  // request is forwarded directly to the next canister.
+  // 
+  // `seen` is the list of canister IDs already in the delegation chain (the
+  // initiator plus every intermediate hop). On an `UnsupportedSpellVersion`
+  // error, this canister refuses to forward to `NEXT_SCROLLS_BITCOIN_CANISTER_ID`
+  // if that ID — or this canister's own ID — already appears in `seen`,
+  // preventing A → B → A and longer cycles.
+  verify_spell_delegated : (text, bool, nat32, vec text) -> (Result);
 }

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -20,6 +20,10 @@ service : () -> {
   // Returns the extracted `NormalizedSpell` (as hex-encoded CBOR) on success.
   // Returns an error string on failure.
   // 
+  // For higher spell versions (not supported by this canister's `charms-client`),
+  // delegates to the `verify_spell` method of the canister specified by
+  // `NEXT_SCROLLS_BITCOIN_CANISTER_ID`.
+  // 
   // The `mock` parameter controls whether mock spells are accepted:
   // - `mock = true`: accepts mock spells (for testing)
   // - `mock = false`: requires real (non-mock) spells

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -8,10 +8,11 @@ use bitcoin::{
     secp256k1,
     sighash::SighashCache,
 };
-use candid::CandidType;
+use candid::{CandidType, Principal};
 use charms_data::util;
 use charms_lib::{bitcoin_tx::BitcoinTx, extract_and_verify_spell, tx::Tx};
 use getrandom::register_custom_getrandom;
+use ic_cdk::call::Call;
 use ic_cdk::management_canister::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, SignWithEcdsaArgs, ecdsa_public_key,
     sign_with_ecdsa,
@@ -25,6 +26,14 @@ use std::{
 };
 
 const SCROLLS: &'static [u8; 7] = b"scrolls";
+
+/// Canister ID of the `scrolls_bitcoin` canister for the *next* major Charms version.
+///
+/// `verify_spell` delegates verification of spells with versions higher than those
+/// supported by this canister's linked `charms-client` to the `verify_spell` method
+/// on that next canister. This allows older `scrolls_bitcoin` canisters to support
+/// newer spell versions by forwarding to the dedicated canister for the next major version.
+const NEXT_SCROLLS_BITCOIN_CANISTER_ID: &str = "";
 
 pub type BitcoinAddresses = BTreeMap<String, String>;
 
@@ -75,15 +84,28 @@ pub fn config() -> Config {
 /// Returns the extracted `NormalizedSpell` (as hex-encoded CBOR) on success.
 /// Returns an error string on failure.
 ///
+/// For higher spell versions (not supported by this canister's `charms-client`),
+/// delegates to the `verify_spell` method of the canister specified by
+/// `NEXT_SCROLLS_BITCOIN_CANISTER_ID`.
+///
 /// The `mock` parameter controls whether mock spells are accepted:
 /// - `mock = true`: accepts mock spells (for testing)
 /// - `mock = false`: requires real (non-mock) spells
 #[ic_cdk::update]
-pub fn verify_spell(tx: String, mock: bool) -> Result<String, String> {
-    verify_spell_impl(&tx, mock).map_err(|e| e.to_string())
+pub async fn verify_spell(tx: String, mock: bool) -> Result<String, String> {
+    verify_spell_impl(tx, mock).await.map_err(|e| e.to_string())
 }
 
-fn verify_spell_impl(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
+async fn verify_spell_impl(tx: String, mock: bool) -> anyhow::Result<String> {
+    // Try local verification first (supports spell versions up to this build's CURRENT_VERSION)
+    match verify_spell_locally(&tx, mock) {
+        Ok(hex) => Ok(hex),
+        Err(e) if is_unsupported_spell_version(&e) => delegate_to_next(tx, mock).await,
+        Err(e) => Err(e),
+    }
+}
+
+fn verify_spell_locally(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
     let tx: Tx = BitcoinTx::from_hex(tx_hex)
         .map_err(|e| anyhow!("Input error: parsing tx: {}", e))?
         .into();
@@ -95,6 +117,39 @@ fn verify_spell_impl(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
     let spell_hex = hex::encode(spell_bytes);
 
     Ok(spell_hex)
+}
+
+fn is_unsupported_spell_version(err: &anyhow::Error) -> bool {
+    err.to_string().contains("unsupported spell version")
+}
+
+async fn delegate_to_next(tx: String, mock: bool) -> anyhow::Result<String> {
+    let next_id = NEXT_SCROLLS_BITCOIN_CANISTER_ID;
+    if next_id.is_empty() {
+        bail!("Input error: unsupported spell version (NEXT_SCROLLS_BITCOIN_CANISTER_ID not set)");
+    }
+
+    let self_id = ic_cdk::api::canister_self().to_string();
+    if next_id == self_id {
+        bail!("Input error: unsupported spell version (next canister ID points to self)");
+    }
+
+    let principal = Principal::from_text(next_id)
+        .context("System error: parsing NEXT_SCROLLS_BITCOIN_CANISTER_ID")?;
+
+    let response = Call::unbounded_wait(principal, "verify_spell")
+        .with_args(&(tx, mock))
+        .await
+        .map_err(|e| anyhow!("System error: inter-canister call failed: {}", e))?;
+
+    let (inner,): (Result<String, String>,) = response
+        .candid_tuple()
+        .map_err(|e| anyhow!("System error: decoding next canister response: {}", e))?;
+
+    match inner {
+        Ok(spell_hex) => Ok(spell_hex),
+        Err(e) => bail!("Input error: next canister: {}", e),
+    }
 }
 
 #[ic_cdk::update]

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -11,14 +11,18 @@ use bitcoin::{
 use candid::{CandidType, Principal};
 use charms_data::util;
 use charms_lib::{
-    CURRENT_VERSION, SPELL_VK, bitcoin_tx::BitcoinTx, extract_and_verify_spell,
+    CURRENT_VERSION, SPELL_VK,
+    bitcoin_tx::BitcoinTx,
+    extract_and_verify_spell,
     tx::{Tx, UnsupportedSpellVersion, committed_normalized_spell},
 };
 use getrandom::register_custom_getrandom;
-use ic_cdk::call::Call;
-use ic_cdk::management_canister::{
-    EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, SignWithEcdsaArgs, ecdsa_public_key,
-    sign_with_ecdsa,
+use ic_cdk::{
+    call::Call,
+    management_canister::{
+        EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, SignWithEcdsaArgs, ecdsa_public_key,
+        sign_with_ecdsa,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -147,10 +151,7 @@ async fn verify_spell_impl(
     match verify_spell_locally(&tx, mock) {
         Ok(hex) => Ok(hex),
         Err(e) => match e.downcast_ref::<UnsupportedSpellVersion>() {
-            Some(uv) => {
-                let v = uv.0;
-                delegate_to_next(tx, mock, v, seen).await
-            }
+            Some(&UnsupportedSpellVersion(v)) => delegate_to_next(tx, mock, v, seen).await,
             None => Err(e),
         },
     }
@@ -169,7 +170,8 @@ fn verify_spell_locally(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
         }
     })?;
 
-    let spell_bytes = util::write(&spell).map_err(|e| anyhow!("System error: serializing spell: {}", e))?;
+    let spell_bytes =
+        util::write(&spell).map_err(|e| anyhow!("System error: serializing spell: {}", e))?;
     let spell_hex = hex::encode(spell_bytes);
 
     Ok(spell_hex)

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -10,7 +10,10 @@ use bitcoin::{
 };
 use candid::{CandidType, Principal};
 use charms_data::util;
-use charms_lib::{bitcoin_tx::BitcoinTx, extract_and_verify_spell, tx::Tx};
+use charms_lib::{
+    CURRENT_VERSION, SPELL_VK, bitcoin_tx::BitcoinTx, extract_and_verify_spell,
+    tx::{Tx, UnsupportedSpellVersion, committed_normalized_spell},
+};
 use getrandom::register_custom_getrandom;
 use ic_cdk::call::Call;
 use ic_cdk::management_canister::{
@@ -30,9 +33,14 @@ const SCROLLS: &'static [u8; 7] = b"scrolls";
 /// Canister ID of the `scrolls_bitcoin` canister for the *next* major Charms version.
 ///
 /// `verify_spell` delegates verification of spells with versions higher than those
-/// supported by this canister's linked `charms-client` to the `verify_spell` method
-/// on that next canister. This allows older `scrolls_bitcoin` canisters to support
-/// newer spell versions by forwarding to the dedicated canister for the next major version.
+/// supported by this canister's linked `charms-client` to the `verify_spell_delegated`
+/// method on that next canister. This allows older `scrolls_bitcoin` canisters to
+/// support newer spell versions by forwarding to the dedicated canister for the next
+/// major version.
+///
+/// Each hop appends its own canister ID to the `seen` list passed downstream, so a
+/// misconfigured chain (A → B → A, A → B → C → A, etc.) is detected before the
+/// forwarding inter-canister call is made.
 const NEXT_SCROLLS_BITCOIN_CANISTER_ID: &str = "";
 
 pub type BitcoinAddresses = BTreeMap<String, String>;
@@ -85,23 +93,65 @@ pub fn config() -> Config {
 /// Returns an error string on failure.
 ///
 /// For higher spell versions (not supported by this canister's `charms-client`),
-/// delegates to the `verify_spell` method of the canister specified by
-/// `NEXT_SCROLLS_BITCOIN_CANISTER_ID`.
+/// delegates to the `verify_spell_delegated` method of the canister specified by
+/// `NEXT_SCROLLS_BITCOIN_CANISTER_ID`, threading the spell version and a list of
+/// already-visited canister IDs to prevent multi-hop delegation cycles.
 ///
 /// The `mock` parameter controls whether mock spells are accepted:
 /// - `mock = true`: accepts mock spells (for testing)
 /// - `mock = false`: requires real (non-mock) spells
 #[ic_cdk::update]
 pub async fn verify_spell(tx: String, mock: bool) -> Result<String, String> {
-    verify_spell_impl(tx, mock).await.map_err(|e| e.to_string())
+    verify_spell_impl(tx, mock, None, Vec::new())
+        .await
+        .map_err(|e| e.to_string())
 }
 
-async fn verify_spell_impl(tx: String, mock: bool) -> anyhow::Result<String> {
-    // Try local verification first (supports spell versions up to this build's CURRENT_VERSION)
+/// Inter-canister entry point for delegated `verify_spell` calls.
+///
+/// `spell_version` is the version learned from a previous hop. If it exceeds
+/// this canister's `CURRENT_VERSION`, local verification is skipped and the
+/// request is forwarded directly to the next canister.
+///
+/// `seen` is the list of canister IDs already in the delegation chain (the
+/// initiator plus every intermediate hop). On an `UnsupportedSpellVersion`
+/// error, this canister refuses to forward to `NEXT_SCROLLS_BITCOIN_CANISTER_ID`
+/// if that ID — or this canister's own ID — already appears in `seen`,
+/// preventing A → B → A and longer cycles.
+#[ic_cdk::update]
+pub async fn verify_spell_delegated(
+    tx: String,
+    mock: bool,
+    spell_version: u32,
+    seen: Vec<String>,
+) -> Result<String, String> {
+    verify_spell_impl(tx, mock, Some(spell_version), seen)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn verify_spell_impl(
+    tx: String,
+    mock: bool,
+    spell_version: Option<u32>,
+    seen: Vec<String>,
+) -> anyhow::Result<String> {
+    // If a previous hop already established the version is beyond what we support,
+    // skip local verification and forward directly.
+    if let Some(v) = spell_version
+        && v > CURRENT_VERSION
+    {
+        return delegate_to_next(tx, mock, v, seen).await;
+    }
     match verify_spell_locally(&tx, mock) {
         Ok(hex) => Ok(hex),
-        Err(e) if is_unsupported_spell_version(&e) => delegate_to_next(tx, mock).await,
-        Err(e) => Err(e),
+        Err(e) => match e.downcast_ref::<UnsupportedSpellVersion>() {
+            Some(uv) => {
+                let v = uv.0;
+                delegate_to_next(tx, mock, v, seen).await
+            }
+            None => Err(e),
+        },
     }
 }
 
@@ -110,8 +160,13 @@ fn verify_spell_locally(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
         .map_err(|e| anyhow!("Input error: parsing tx: {}", e))?
         .into();
 
-    let spell = extract_and_verify_spell(&tx, mock)
-        .map_err(|e| anyhow!("Input error: extracting and verifying spell: {}", e))?;
+    let spell = committed_normalized_spell(SPELL_VK, &tx, mock).map_err(|e| {
+        if e.is::<UnsupportedSpellVersion>() {
+            e
+        } else {
+            anyhow!("Input error: extracting and verifying spell: {}", e)
+        }
+    })?;
 
     let spell_bytes = util::write(&spell).map_err(|e| anyhow!("System error: serializing spell: {}", e))?;
     let spell_hex = hex::encode(spell_bytes);
@@ -119,26 +174,41 @@ fn verify_spell_locally(tx_hex: &str, mock: bool) -> anyhow::Result<String> {
     Ok(spell_hex)
 }
 
-fn is_unsupported_spell_version(err: &anyhow::Error) -> bool {
-    err.to_string().contains("unsupported spell version")
-}
-
-async fn delegate_to_next(tx: String, mock: bool) -> anyhow::Result<String> {
+async fn delegate_to_next(
+    tx: String,
+    mock: bool,
+    spell_version: u32,
+    mut seen: Vec<String>,
+) -> anyhow::Result<String> {
     let next_id = NEXT_SCROLLS_BITCOIN_CANISTER_ID;
     if next_id.is_empty() {
-        bail!("Input error: unsupported spell version (NEXT_SCROLLS_BITCOIN_CANISTER_ID not set)");
+        bail!(
+            "Input error: unsupported spell version {} (NEXT_SCROLLS_BITCOIN_CANISTER_ID not set)",
+            spell_version
+        );
     }
 
     let self_id = ic_cdk::api::canister_self().to_string();
     if next_id == self_id {
-        bail!("Input error: unsupported spell version (next canister ID points to self)");
+        bail!(
+            "Input error: unsupported spell version {} (next canister ID points to self)",
+            spell_version
+        );
     }
+    if seen.iter().any(|id| id == next_id) {
+        bail!(
+            "Input error: delegation cycle detected (next canister {} already in chain {:?})",
+            next_id,
+            seen
+        );
+    }
+    seen.push(self_id);
 
     let principal = Principal::from_text(next_id)
         .context("System error: parsing NEXT_SCROLLS_BITCOIN_CANISTER_ID")?;
 
-    let response = Call::unbounded_wait(principal, "verify_spell")
-        .with_args(&(tx, mock))
+    let response = Call::unbounded_wait(principal, "verify_spell_delegated")
+        .with_args(&(tx, mock, spell_version, seen))
         .await
         .map_err(|e| anyhow!("System error: inter-canister call failed: {}", e))?;
 

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -116,8 +116,9 @@ pub async fn verify_spell(tx: String, mock: bool) -> Result<String, String> {
 /// `seen` is the list of canister IDs already in the delegation chain (the
 /// initiator plus every intermediate hop). On an `UnsupportedSpellVersion`
 /// error, this canister refuses to forward to `NEXT_SCROLLS_BITCOIN_CANISTER_ID`
-/// if that ID — or this canister's own ID — already appears in `seen`,
-/// preventing A → B → A and longer cycles.
+/// if that next ID equals this canister's own ID (A → A) or already appears
+/// in `seen` (A → B → ... → A). After the checks pass, this canister appends
+/// its own ID to `seen` before calling the next hop.
 #[ic_cdk::update]
 pub async fn verify_spell_delegated(
     tx: String,


### PR DESCRIPTION
## Summary

Introduces support for the planned architecture where each major Charms version gets its own dedicated `scrolls_bitcoin` canister.

- Add `NEXT_SCROLLS_BITCOIN_CANISTER_ID` const (empty by default).
- `verify_spell` (added in #178) now attempts local verification first.
- On "unsupported spell version" error, it delegates via inter-canister call to the `verify_spell` method of the next major version's canister (when the const is configured).

This allows an older `scrolls_bitcoin` canister to transparently verify spells from newer protocol versions by forwarding the request.

## Changes

- `scrolls/src/scrolls_bitcoin/src/lib.rs`:
  - New const + documentation.
  - `verify_spell` made `async` (required for inter-canister calls; interface unchanged).
  - Local verification extracted to `verify_spell_locally`.
  - New `delegate_to_next` helper using the modern `ic_cdk::call::Call` builder API + `candid_tuple` decoding.
  - Defensive self-call guard.

## Deployment note

Before deploying (or upgrading) the `scrolls_bitcoin` canister for a given major version, set `NEXT_SCROLLS_BITCOIN_CANISTER_ID` to the canister ID of the *next* major version's dedicated canister. The value is baked in at build time.

## Testing

- `cargo check -p scrolls_bitcoin --target wasm32-unknown-unknown` ✅ (clean)
- Local verification path unchanged (exercises the same `extract_and_verify_spell` code used by `sign`).