### PR TITLE
feat(scrolls): expose cycles_balance + deposit_cycles for blackholing

### DIFF
--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -5,6 +5,7 @@ type Config = record {
   fee_basis_points : nat64;
 };
 type Result = variant { Ok : text; Err : text };
+type Result_1 = variant { Ok : nat; Err : text };
 type SignInput = record { nonce : nat64; index : nat64 };
 type SignRequest = record {
   prev_txs : vec text;
@@ -14,6 +15,16 @@ type SignRequest = record {
 service : () -> {
   address : (text, nat64) -> (Result);
   config : () -> (Config) query;
+  // Current cycle balance of this canister.
+  // 
+  // Exposed as a query so anyone can monitor the canister after blackholing —
+  // `canister_status` on the management canister is controller-only and is
+  // unreachable once the controller list is empty.
+  cycles_balance : () -> (nat) query;
+  // Accept cycles attached to this call (at least `MIN_DEPOSIT_CYCLES`) and
+  // return the new balance. If fewer cycles are attached, nothing is accepted
+  // and the system refunds the caller automatically.
+  deposit_cycles : () -> (Result_1);
   sign : (text, SignRequest) -> (Result);
   // Verify that a Bitcoin transaction carries a correct spell.
   // 

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -34,6 +34,12 @@ use std::{
 
 const SCROLLS: &'static [u8; 7] = b"scrolls";
 
+/// Minimum cycles accepted by `deposit_cycles`. Once the canister is blackholed
+/// it can never be topped up by its (now non-existent) controllers, so anybody
+/// must be able to add cycles to keep it alive — but a minimum keeps the
+/// endpoint from being spammed with dust.
+const MIN_DEPOSIT_CYCLES: u128 = 1_000_000_000_000;
+
 /// Canister ID of the `scrolls_bitcoin` canister for the *next* major Charms version.
 ///
 /// `verify_spell` delegates verification of spells with versions higher than those
@@ -89,6 +95,32 @@ fn do_init() {
 #[ic_cdk::query]
 pub fn config() -> Config {
     CONFIG.clone()
+}
+
+/// Current cycle balance of this canister.
+///
+/// Exposed as a query so anyone can monitor the canister after blackholing —
+/// `canister_status` on the management canister is controller-only and is
+/// unreachable once the controller list is empty.
+#[ic_cdk::query]
+pub fn cycles_balance() -> u128 {
+    ic_cdk::api::canister_cycle_balance()
+}
+
+/// Accept cycles attached to this call (at least `MIN_DEPOSIT_CYCLES`) and
+/// return the new balance. If fewer cycles are attached, nothing is accepted
+/// and the system refunds the caller automatically.
+#[ic_cdk::update]
+pub fn deposit_cycles() -> Result<u128, String> {
+    let available = ic_cdk::api::msg_cycles_available();
+    if available < MIN_DEPOSIT_CYCLES {
+        return Err(format!(
+            "Input error: insufficient cycles attached: provided {}, minimum {}",
+            available, MIN_DEPOSIT_CYCLES
+        ));
+    }
+    let _ = ic_cdk::api::msg_cycles_accept(available);
+    Ok(ic_cdk::api::canister_cycle_balance())
 }
 
 /// Verify that a Bitcoin transaction carries a correct spell.

--- a/scrolls/src/scrolls_cardano/scrolls_cardano.did
+++ b/scrolls/src/scrolls_cardano/scrolls_cardano.did
@@ -25,6 +25,7 @@ type HttpRequestResult = record {
   headers : vec HttpHeader;
 };
 type Result = variant { Ok : text; Err : text };
+type Result_1 = variant { Ok : nat; Err : text };
 // # Transform Args.
 // 
 // ```text
@@ -44,6 +45,16 @@ type TransformArgs = record {
 service : () -> {
   certify_final : (text) -> (Result);
   config : () -> (Config) query;
+  // Current cycle balance of this canister.
+  // 
+  // Exposed as a query so anyone can monitor the canister after blackholing —
+  // `canister_status` on the management canister is controller-only and is
+  // unreachable once the controller list is empty.
+  cycles_balance : () -> (nat) query;
+  // Accept cycles attached to this call (at least `MIN_DEPOSIT_CYCLES`) and
+  // return the new balance. If fewer cycles are attached, nothing is accepted
+  // and the system refunds the caller automatically.
+  deposit_cycles : () -> (Result_1);
   finality_vkey : () -> (Result);
   sign : (text) -> (Result);
   // Transform function for HTTP outcalls. Strips headers so all replicas reach consensus

--- a/scrolls/src/scrolls_cardano/src/lib.rs
+++ b/scrolls/src/scrolls_cardano/src/lib.rs
@@ -26,6 +26,12 @@ use std::{collections::BTreeMap, sync::LazyLock};
 const SCROLLS: &[u8] = b"scrolls";
 const FINALITY: &[u8] = b"finality";
 
+/// Minimum cycles accepted by `deposit_cycles`. Once the canister is blackholed
+/// it can never be topped up by its (now non-existent) controllers, so anybody
+/// must be able to add cycles to keep it alive — but a minimum keeps the
+/// endpoint from being spammed with dust.
+const MIN_DEPOSIT_CYCLES: u128 = 1_000_000_000_000;
+
 pub type CardanoAddresses = BTreeMap<String, String>;
 
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
@@ -61,6 +67,32 @@ fn do_init() {
 #[ic_cdk::query]
 pub fn config() -> Config {
     CONFIG.clone()
+}
+
+/// Current cycle balance of this canister.
+///
+/// Exposed as a query so anyone can monitor the canister after blackholing —
+/// `canister_status` on the management canister is controller-only and is
+/// unreachable once the controller list is empty.
+#[ic_cdk::query]
+pub fn cycles_balance() -> u128 {
+    ic_cdk::api::canister_cycle_balance()
+}
+
+/// Accept cycles attached to this call (at least `MIN_DEPOSIT_CYCLES`) and
+/// return the new balance. If fewer cycles are attached, nothing is accepted
+/// and the system refunds the caller automatically.
+#[ic_cdk::update]
+pub fn deposit_cycles() -> Result<u128, String> {
+    let available = ic_cdk::api::msg_cycles_available();
+    if available < MIN_DEPOSIT_CYCLES {
+        return Err(format!(
+            "Input error: insufficient cycles attached: provided {}, minimum {}",
+            available, MIN_DEPOSIT_CYCLES
+        ));
+    }
+    let _ = ic_cdk::api::msg_cycles_accept(available);
+    Ok(ic_cdk::api::canister_cycle_balance())
 }
 
 const ED25519_VKEY: [u8; 32] =


### PR DESCRIPTION
## Summary
- Add a `cycles_balance` query and a `deposit_cycles` update (min 1T cycles) to both `scrolls_bitcoin` and `scrolls_cardano`.
- After blackholing, `canister_status` on the management canister is controller-only and unreachable, so the canister itself must expose its cycle balance and accept top-ups. These two methods let anyone keep the canisters alive once their controllers are removed, while the 1T minimum keeps the deposit endpoint from being spammed with dust.
- Cycles attached below the minimum are not accepted and the system refunds the caller automatically.

## Other prerequisites to land before actually blackholing (not in this PR)
- Set `NEXT_SCROLLS_BITCOIN_CANISTER_ID` (currently `\"\"`) to the v(next) canister's principal in one final upgrade, otherwise newer spell versions will be permanently rejected.
- `scrolls_cardano` has no forwarding logic — consider porting the delegation pattern over before freezing the controller list.
- All compile-time config (fee addresses, fee parameters, hardcoded `ED25519_VKEY`) is frozen by blackholing; double-check production values.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown -p scrolls_bitcoin -p scrolls_cardano`
- [x] `cargo clippy --target wasm32-unknown-unknown -p scrolls_bitcoin -p scrolls_cardano` (no new warnings)
- [ ] On a test deployment: `dfx canister call <id> cycles_balance` returns the live balance
- [ ] On a test deployment: `dfx canister call <id> deposit_cycles --with-cycles 999999999999` returns `Err` and refunds
- [ ] On a test deployment: `dfx canister call <id> deposit_cycles --with-cycles 1000000000000` returns `Ok(new_balance)` and `cycles_balance` reflects the increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)