### PR TITLE
chore(scrolls): add icp-cli config alongside dfx.json

### DIFF
--- a/scrolls/.gitignore
+++ b/scrolls/.gitignore
@@ -10,6 +10,9 @@
 # dfx temporary files
 .dfx/
 
+# icp-cli cache (data/ is committed: holds mainnet canister-id mappings)
+.icp/cache/
+
 # generated files
 **/declarations/
 

--- a/scrolls/.icp/data/mappings/ic.ids.json
+++ b/scrolls/.icp/data/mappings/ic.ids.json
@@ -1,0 +1,4 @@
+{
+  "scrolls_bitcoin": "lmbwh-3qaaa-aaaak-qunha-cai",
+  "scrolls_cardano": "tty7k-waaaa-aaaak-qvngq-cai"
+}

--- a/scrolls/icp.yaml
+++ b/scrolls/icp.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://github.com/dfinity/icp-cli/raw/refs/tags/v0.2.0/docs/schemas/icp-yaml-schema.json
+
+canisters:
+  - name: scrolls_bitcoin
+    recipe:
+      type: "@dfinity/rust@v3.2.0"
+      configuration:
+        package: scrolls_bitcoin
+        candid: src/scrolls_bitcoin/scrolls_bitcoin.did
+
+  - name: scrolls_cardano
+    recipe:
+      type: "@dfinity/rust@v3.2.0"
+      configuration:
+        package: scrolls_cardano
+        candid: src/scrolls_cardano/scrolls_cardano.did


### PR DESCRIPTION
## Summary
- Adds `scrolls/icp.yaml` so the project can be managed with [icp-cli](https://cli.internetcomputer.org) (dfx is deprecated)
- Adds `scrolls/.icp/data/mappings/ic.ids.json` mapping `scrolls_bitcoin` / `scrolls_cardano` to their mainnet canister IDs
- Gitignores `.icp/cache/` only — `.icp/data/` is committed since it holds the mainnet canister-id mappings (per the [migration guide](https://github.com/dfinity/icp-cli/blob/main/docs/migration/from-dfx.md))
- `dfx.json` and `canister_ids.json` are untouched, so both tools work side by side

After this lands, contributors with icp-cli installed can run, for example:

```bash
cd scrolls
icp canister status -e ic
icp canister top-up scrolls_bitcoin -e ic --amount 1t
```

## Test plan
- [x] `icp canister status -e ic` returns running status for both canisters with correct controllers/cycles
- [x] Existing `dfx` workflows still work (no changes to `dfx.json` / `canister_ids.json`)
- [ ] Reviewer with icp-cli installed verifies `icp canister status -e ic` works for them too

🤖 Generated with [Claude Code](https://claude.com/claude-code)