### PR TITLE
chore(scrolls): set NEXT_SCROLLS_BITCOIN_CANISTER_ID to v15 canister

### DIFF
--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -49,7 +49,7 @@ const MIN_DEPOSIT_CYCLES: u128 = 1_000_000_000_000;
 /// Each hop appends its own canister ID to the `seen` list passed downstream, so a
 /// misconfigured chain (A → B → A, A → B → C → A, etc.) is detected before the
 /// forwarding inter-canister call is made.
-const NEXT_SCROLLS_BITCOIN_CANISTER_ID: &str = "";
+const NEXT_SCROLLS_BITCOIN_CANISTER_ID: &str = "rpgc6-oqaaa-aaaak-qy3uq-cai";
 
 pub type BitcoinAddresses = BTreeMap<String, String>;
 


### PR DESCRIPTION
## Summary
- Sets `NEXT_SCROLLS_BITCOIN_CANISTER_ID` in `scrolls_bitcoin` to `rpgc6-oqaaa-aaaak-qy3uq-cai`, wiring the v14 canister to forward to `scrolls_bitcoin_v15` as the next hop in the upgrade chain.

## Test plan
- [x] Verify the canister ID matches the deployed `scrolls_bitcoin_v15` canister.
- [ ] Confirm forwarding behavior end-to-end against a v15 deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)