### PR TITLE
chore(scrolls): rename scrolls_bitcoin canister to scrolls_bitcoin_v14

### DIFF
--- a/scrolls/.icp/data/mappings/ic.ids.json
+++ b/scrolls/.icp/data/mappings/ic.ids.json
@@ -1,5 +1,5 @@
 {
-  "scrolls_bitcoin": "lmbwh-3qaaa-aaaak-qunha-cai",
+  "scrolls_bitcoin_v14": "lmbwh-3qaaa-aaaak-qunha-cai",
   "scrolls_bitcoin_v15": "rpgc6-oqaaa-aaaak-qy3uq-cai",
   "scrolls_cardano": "tty7k-waaaa-aaaak-qvngq-cai"
 }

--- a/scrolls/CLAUDE.md
+++ b/scrolls/CLAUDE.md
@@ -12,7 +12,7 @@ Scrolls is a set of Internet Computer (ICP) canisters that sign Bitcoin and Card
 
 ```bash
 # Build canisters
-dfx build scrolls_bitcoin
+dfx build scrolls_bitcoin_v14
 dfx build scrolls_cardano
 
 # Run all workspace tests
@@ -59,7 +59,7 @@ The Cargo workspace contains two crates (`scrolls-api` is excluded — it has it
 
 ### Canister IDs (IC Mainnet)
 
-- scrolls_bitcoin: `lmbwh-3qaaa-aaaak-qunha-cai`
+- scrolls_bitcoin_v14: `lmbwh-3qaaa-aaaak-qunha-cai`
 - scrolls_cardano: `tty7k-waaaa-aaaak-qvngq-cai`
 
 ### Crate-specific notes

--- a/scrolls/canister_ids.json
+++ b/scrolls/canister_ids.json
@@ -1,5 +1,5 @@
 {
-  "scrolls_bitcoin": {
+  "scrolls_bitcoin_v14": {
     "ic": "lmbwh-3qaaa-aaaak-qunha-cai"
   },
   "scrolls_bitcoin_v15": {

--- a/scrolls/dfx.json
+++ b/scrolls/dfx.json
@@ -1,6 +1,6 @@
 {
   "canisters": {
-    "scrolls_bitcoin": {
+    "scrolls_bitcoin_v14": {
       "candid": "src/scrolls_bitcoin/scrolls_bitcoin.did",
       "package": "scrolls_bitcoin",
       "type": "rust"

--- a/scrolls/icp.yaml
+++ b/scrolls/icp.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://github.com/dfinity/icp-cli/raw/refs/tags/v0.2.0/docs/schemas/icp-yaml-schema.json
 
 canisters:
-  - name: scrolls_bitcoin
+  - name: scrolls_bitcoin_v14
     recipe:
       type: "@dfinity/rust@v3.2.0"
       configuration:

--- a/scrolls/src/scrolls-api/src/lib.rs
+++ b/scrolls/src/scrolls-api/src/lib.rs
@@ -26,7 +26,7 @@ use worker::*;
 static SCROLLS_BITCOIN: LazyLock<Principal> = LazyLock::new(|| {
     let canister_ids_json = include_str!("../../../canister_ids.json");
     let canister_ids: serde_json::Value = serde_json::from_str(canister_ids_json).unwrap();
-    let canister_id = canister_ids["scrolls_bitcoin"]["ic"].as_str().unwrap();
+    let canister_id = canister_ids["scrolls_bitcoin_v14"]["ic"].as_str().unwrap();
     Principal::from_text(canister_id).unwrap()
 });
 


### PR DESCRIPTION
## Summary
- Renames the deployment canister entry `scrolls_bitcoin` → `scrolls_bitcoin_v14` in `icp.yaml`, `dfx.json`, `canister_ids.json`, `.icp/data/mappings/ic.ids.json`, and the `scrolls-api` canister-ID lookup.
- The Rust crate/package name `scrolls_bitcoin` is unchanged — both v14 and v15 share the same package.
- IC canister ID is unchanged (`lmbwh-3qaaa-aaaak-qunha-cai`).

## Test plan
- [x] `icp build scrolls_bitcoin_v14 -e ic` succeeds.
- [ ] Verify `scrolls-api` still resolves the v14 canister principal at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)