### PR TITLE
feat(scrolls_bitcoin): rename sign to sign_and_submit, broadcast via ICP Bitcoin

### DIFF
--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -1215,6 +1215,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "datasize"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65c07d59e45d77a8bda53458c24a828893a99ac6cdd9c84111e09176ab739a2"
+dependencies = [
+ "datasize_derive",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613e4ee15899913285b7612004bbd490abd605be7b11d35afada5902fb6b91d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "deepsize2"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1909,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-btc-interface"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b07cca9319498684a7477a77a66d87377ecd698b5465a3b8523484fcca16bff"
+dependencies = [
+ "candid",
+ "datasize",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-cdk"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1934,17 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ic-cdk-bitcoin-canister"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bf6dd432d5750428b8658bbe6fb0cbc26f6ad634e20d48994f48d7bf84da9"
+dependencies = [
+ "candid",
+ "ic-btc-interface",
+ "ic-cdk",
 ]
 
 [[package]]
@@ -2646,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3660,6 +3703,7 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "ic-cdk",
+ "ic-cdk-bitcoin-canister",
  "ic-cdk-management-canister",
  "serde",
  "serde_yaml",

--- a/scrolls/src/scrolls-api/src/lib.rs
+++ b/scrolls/src/scrolls-api/src/lib.rs
@@ -274,15 +274,21 @@ pub struct SignRequest {
     pub tx_to_sign: String,
 }
 
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
+pub struct SignAndSubmitResult {
+    pub txid: String,
+    pub wtxid: String,
+}
+
 #[worker::send]
 pub async fn sign(
     State(app_state): State<AppState>,
     Path(network): Path<String>,
     Json(sign_request): Json<SignRequest>,
-) -> Result<Json<String>, (StatusCode, String)> {
+) -> Result<Json<SignAndSubmitResult>, (StatusCode, String)> {
     let agent = app_state.agent.clone();
     let update_response = agent
-        .update(&SCROLLS_BITCOIN, "sign")
+        .update(&SCROLLS_BITCOIN, "sign_and_submit")
         .with_arg(Encode!(&network, &sign_request).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -305,7 +311,7 @@ pub async fn sign(
                 format!("System error: waiting for response: {}", e),
             )
         })?;
-    let result = Decode!(&response, Result<String, String>)
+    let result = Decode!(&response, Result<SignAndSubmitResult, String>)
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/scrolls/src/scrolls-api/src/lib.rs
+++ b/scrolls/src/scrolls-api/src/lib.rs
@@ -292,7 +292,7 @@ pub async fn sign(
         .with_arg(Encode!(&network, &sign_request).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("System error: encoding sign request: {}", e),
+                format!("System error: encoding sign_and_submit request: {}", e),
             )
         })?)
         .call()
@@ -300,7 +300,7 @@ pub async fn sign(
         .map_err(|e| {
             (
                 StatusCode::BAD_GATEWAY,
-                format!("System error: calling sign method: {}", e),
+                format!("System error: calling sign_and_submit method: {}", e),
             )
         })?;
     let response = wait_for_response(agent, update_response)
@@ -315,7 +315,7 @@ pub async fn sign(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("System error: decoding sign response: {}", e),
+                format!("System error: decoding sign_and_submit response: {}", e),
             )
         })?
         .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Upstream error: {}", e)))?;

--- a/scrolls/src/scrolls_bitcoin/Cargo.toml
+++ b/scrolls/src/scrolls_bitcoin/Cargo.toml
@@ -18,6 +18,7 @@ charms-data = { version = "15.0.0", path = "../../../charms-data" }
 charms-lib = { version = "15.0.0", path = "../../../charms-lib" }
 getrandom = { version = "0.2", features = ["custom"] }
 ic-cdk = { version = "0.20.1" }
+ic-cdk-bitcoin-canister = { version = "0.2" }
 ic-cdk-management-canister = { version = "0.1" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = { version = "0.9.34" }

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -6,6 +6,8 @@ type Config = record {
 };
 type Result = variant { Ok : text; Err : text };
 type Result_1 = variant { Ok : nat; Err : text };
+type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
+type SignAndSubmitResult = record { txid : text; wtxid : text };
 type SignInput = record { nonce : nat64; index : nat64 };
 type SignRequest = record {
   prev_txs : vec text;
@@ -25,7 +27,7 @@ service : () -> {
   // return the new balance. If fewer cycles are attached, nothing is accepted
   // and the system refunds the caller automatically.
   deposit_cycles : () -> (Result_1);
-  sign : (text, SignRequest) -> (Result);
+  sign_and_submit : (text, SignRequest) -> (Result_2);
   // Verify that a Bitcoin transaction carries a correct spell.
   // 
   // Returns the extracted `NormalizedSpell` (as hex-encoded CBOR) on success.

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, anyhow, bail, ensure};
 use bitcoin::{
     Address, CompressedPublicKey, EcdsaSighashType, Network, ScriptBuf, SegwitV0Sighash,
     Transaction, Txid,
-    consensus::encode::{deserialize_hex, serialize_hex},
+    consensus::encode::{deserialize_hex, serialize},
     ecdsa::Signature,
     hashes::Hash,
     secp256k1,
@@ -18,6 +18,9 @@ use charms_lib::{
 };
 use getrandom::register_custom_getrandom;
 use ic_cdk::call::Call;
+use ic_cdk_bitcoin_canister::{
+    Network as BtcNetwork, SendTransactionRequest, bitcoin_send_transaction,
+};
 use ic_cdk_management_canister::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, SignWithEcdsaArgs, ecdsa_public_key,
     sign_with_ecdsa,
@@ -318,14 +321,26 @@ pub struct SignRequest {
     tx_to_sign: String,
 }
 
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
+pub struct SignAndSubmitResult {
+    pub txid: String,
+    pub wtxid: String,
+}
+
 #[ic_cdk::update]
-pub async fn sign(network: String, sign_request: SignRequest) -> Result<String, String> {
+pub async fn sign_and_submit(
+    network: String,
+    sign_request: SignRequest,
+) -> Result<SignAndSubmitResult, String> {
     do_sign(network, sign_request)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn do_sign(network_str: String, sign_request: SignRequest) -> anyhow::Result<String> {
+async fn do_sign(
+    network_str: String,
+    sign_request: SignRequest,
+) -> anyhow::Result<SignAndSubmitResult> {
     let network = check_network(&network_str)?;
     let SignRequest {
         sign_inputs,
@@ -347,6 +362,8 @@ async fn do_sign(network_str: String, sign_request: SignRequest) -> anyhow::Resu
         "Input error: transaction must have at least one input"
     );
 
+    check_existing_witnesses(&bitcoin_tx, &sign_inputs)?;
+
     let prev_txs: BTreeMap<Txid, Transaction> = txid_to_tx(&bitcoin_tx, prev_txs)?;
     let spell = verify_spell_impl(tx_to_sign, true, None, Vec::new())
         .await
@@ -355,9 +372,57 @@ async fn do_sign(network_str: String, sign_request: SignRequest) -> anyhow::Resu
 
     check_fee(network, &prev_txs, &bitcoin_tx)?;
 
-    let bitcoin_tx = sign_tx(sign_inputs, prev_txs, bitcoin_tx).await?;
+    let signed_tx = sign_tx(sign_inputs, &prev_txs, bitcoin_tx).await?;
 
-    Ok(serialize_hex(&bitcoin_tx))
+    submit_tx(network, &signed_tx).await?;
+
+    Ok(SignAndSubmitResult {
+        txid: signed_tx.compute_txid().to_string(),
+        wtxid: signed_tx.compute_wtxid().to_string(),
+    })
+}
+
+/// Ensure every input that this call is NOT going to sign already carries a non-empty
+/// witness. After the call, every input must be spendable, and the only ones we will
+/// populate here are those listed in `sign_inputs` — everything else must already be
+/// signed by the caller.
+fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[SignInput]) -> anyhow::Result<()> {
+    let signing: HashSet<usize> = sign_inputs.iter().map(|s| s.index).collect();
+    for (i, input) in tx.input.iter().enumerate() {
+        if signing.contains(&i) {
+            ensure!(
+                input.witness.is_empty(),
+                "Input error: input {} already has a witness but is in sign_inputs",
+                i
+            );
+            continue;
+        }
+        ensure!(
+            !input.witness.is_empty(),
+            "Input error: input {} has no witness and is not being signed",
+            i
+        );
+    }
+    Ok(())
+}
+
+async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
+    let btc_network = match network {
+        Network::Bitcoin => BtcNetwork::Mainnet,
+        Network::Testnet4 => BtcNetwork::Testnet,
+        _ => bail!(
+            "Input error: unsupported network for submission: {}",
+            network
+        ),
+    };
+    let request = SendTransactionRequest {
+        transaction: serialize(tx),
+        network: btc_network.into(),
+    };
+    bitcoin_send_transaction(&request)
+        .await
+        .map_err(|e| anyhow!("System error: bitcoin_send_transaction failed: {}", e))?;
+    Ok(())
 }
 
 fn check_network(network: &str) -> anyhow::Result<bitcoin::Network> {
@@ -450,7 +515,7 @@ fn configured_fee_script_pubkey(network: Network) -> ScriptBuf {
 
 async fn sign_tx(
     sign_inputs: Vec<SignInput>,
-    prev_txs: BTreeMap<Txid, Transaction>,
+    prev_txs: &BTreeMap<Txid, Transaction>,
     mut bitcoin_tx: Transaction,
 ) -> anyhow::Result<Transaction> {
     // Validate input indices: must be unique and within signable range

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -382,26 +382,47 @@ async fn do_sign(
     })
 }
 
-/// Ensure every input that this call is NOT going to sign already carries a non-empty
-/// witness. After the call, every input must be spendable, and the only ones we will
-/// populate here are those listed in `sign_inputs` — everything else must already be
-/// signed by the caller.
+/// Validate `sign_inputs` and ensure every input that this call is NOT going to
+/// sign already carries a signature (witness or `script_sig`). After the call,
+/// every input must be spendable, and the only ones we will populate here are
+/// those listed in `sign_inputs` — everything else must already be signed by
+/// the caller.
+///
+/// Bounds and duplicate detection happen first so that an out-of-range or
+/// repeated `sign_inputs` index produces an accurate error message instead of
+/// a misleading "input N has no witness" report.
 fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[SignInput]) -> anyhow::Result<()> {
-    let signing: HashSet<usize> = sign_inputs.iter().map(|s| s.index).collect();
+    let input_count = tx.input.len();
+    let mut signing: HashSet<usize> = HashSet::new();
+    for sign_input in sign_inputs {
+        let idx = sign_input.index;
+        ensure!(
+            idx < input_count,
+            "Input error: input_index {} is out of range [0, {})",
+            idx,
+            input_count
+        );
+        ensure!(
+            signing.insert(idx),
+            "Input error: duplicate input_index: {}",
+            idx
+        );
+    }
     for (i, input) in tx.input.iter().enumerate() {
+        let is_signed = !input.witness.is_empty() || !input.script_sig.is_empty();
         if signing.contains(&i) {
             ensure!(
-                input.witness.is_empty(),
-                "Input error: input {} already has a witness but is in sign_inputs",
+                !is_signed,
+                "Input error: input {} already has a signature but is in sign_inputs",
                 i
             );
-            continue;
+        } else {
+            ensure!(
+                is_signed,
+                "Input error: input {} has no signature and is not being signed",
+                i
+            );
         }
-        ensure!(
-            !input.witness.is_empty(),
-            "Input error: input {} has no witness and is not being signed",
-            i
-        );
     }
     Ok(())
 }
@@ -518,24 +539,6 @@ async fn sign_tx(
     prev_txs: &BTreeMap<Txid, Transaction>,
     mut bitcoin_tx: Transaction,
 ) -> anyhow::Result<Transaction> {
-    // Validate input indices: must be unique and within signable range
-    let signable_count = signable_inputs(&bitcoin_tx);
-    let mut seen_indices: HashSet<usize> = HashSet::new();
-    for sign_input in &sign_inputs {
-        let idx = sign_input.index;
-        ensure!(
-            idx < signable_count,
-            "Input error: input_index {} is out of signable range [0, {})",
-            idx,
-            signable_count
-        );
-        ensure!(
-            seen_indices.insert(idx),
-            "Input error: duplicate input_index: {}",
-            idx
-        );
-    }
-
     for sign_input in sign_inputs {
         let input_index = sign_input.index;
         let nonce = sign_input.nonce;


### PR DESCRIPTION
## Summary

- Renames the `scrolls_bitcoin` canister method `sign` to `sign_and_submit` (and updates the `scrolls-api` call site to match).
- `do_sign` now verifies every input *not* listed in `sign_inputs` already carries a non-empty witness, so after signing the requested inputs the transaction is fully witnessed.
- After signing, broadcasts the transaction through the standard ICP Bitcoin integration (`ic-cdk-bitcoin-canister::bitcoin_send_transaction`, mainnet/testnet routing keyed off `bitcoin::Network`). Invalid transactions surface as errors from the management canister, so no separate consensus check is performed in the canister.
- The method now returns a `SignAndSubmitResult` with `txid` and `wtxid` instead of the full signed transaction hex.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p scrolls_bitcoin`
- [x] `cargo check -p scrolls_bitcoin` (host)
- [x] `cargo test -p scrolls_bitcoin`
- [x] `cargo check` against `scrolls/src/scrolls-api`
- [ ] Deploy to a testnet canister and exercise `sign_and_submit` end-to-end (broadcast a real testnet4 tx)