### PR TITLE
scrolls_bitcoin: deterministic address derivation from (tx_in_0, out_i) + API simplifications

### DIFF
--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -10,11 +10,11 @@ type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
 type SignAndSubmitResult = record { txid : text; wtxid : text };
 type SignRequest = record {
   prev_txs : vec text;
-  sign_inputs : vec nat64;
+  sign_inputs : vec nat32;
   tx_to_sign : text;
 };
 service : () -> {
-  address : (text, text, nat64) -> (Result);
+  address : (text, text, nat32) -> (Result);
   config : () -> (Config) query;
   // Current cycle balance of this canister.
   // 

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -4,9 +4,10 @@ type Config = record {
   fixed_cost : nat64;
   fee_basis_points : nat64;
 };
-type Result = variant { Ok : text; Err : text };
+type Result = variant { Ok : vec text; Err : text };
 type Result_1 = variant { Ok : nat; Err : text };
 type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
+type Result_3 = variant { Ok : text; Err : text };
 type SignAndSubmitResult = record { txid : text; wtxid : text };
 type SignRequest = record {
   prev_txs : vec text;
@@ -14,7 +15,7 @@ type SignRequest = record {
   tx_to_sign : text;
 };
 service : () -> {
-  address : (text, text, nat32) -> (Result);
+  addresses : (text, text, vec nat32) -> (Result);
   config : () -> (Config) query;
   // Current cycle balance of this canister.
   // 
@@ -40,7 +41,7 @@ service : () -> {
   // The `mock` parameter controls whether mock spells are accepted:
   // - `mock = true`: accepts mock spells (for testing)
   // - `mock = false`: requires real (non-mock) spells
-  verify_spell : (text, bool) -> (Result);
+  verify_spell : (text, bool) -> (Result_3);
   // Inter-canister entry point for delegated `verify_spell` calls.
   // 
   // `spell_version` is the version learned from a previous hop. If it exceeds
@@ -53,5 +54,5 @@ service : () -> {
   // if that next ID equals this canister's own ID (A → A) or already appears
   // in `seen` (A → B → ... → A). After the checks pass, this canister appends
   // its own ID to `seen` before calling the next hop.
-  verify_spell_delegated : (text, bool, nat32, vec text) -> (Result);
+  verify_spell_delegated : (text, bool, nat32, vec text) -> (Result_3);
 }

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -8,14 +8,13 @@ type Result = variant { Ok : text; Err : text };
 type Result_1 = variant { Ok : nat; Err : text };
 type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
 type SignAndSubmitResult = record { txid : text; wtxid : text };
-type SignInput = record { nonce : nat64; index : nat64 };
 type SignRequest = record {
   prev_txs : vec text;
-  sign_inputs : vec SignInput;
+  sign_inputs : vec nat64;
   tx_to_sign : text;
 };
 service : () -> {
-  address : (text, nat64) -> (Result);
+  address : (text, text, nat64) -> (Result);
   config : () -> (Config) query;
   // Current cycle balance of this canister.
   // 

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -15,6 +15,21 @@ type SignRequest = record {
   tx_to_sign : text;
 };
 service : () -> {
+  // Returns Scroll-controlled P2WPKH addresses for the given network and derivation anchor.
+  // 
+  // `tx_in_0` is a string of the form `txid_hex:vout` (or block height for coinbase).
+  // It identifies the unique "anchor" used for key derivation:
+  // 
+  // * For a normal (non-coinbase) output, this is the outpoint (`{txid}:{vout}`) of the *first
+  // input* of the transaction that created the output(s) being addressed.
+  // * For an output created by a **coinbase** transaction, use the all-zeros txid (the txid that
+  // appears as the first input's `txid` of the coinbase transaction itself) together with the
+  // block height (as a decimal integer) in place of the vout. Example:
+  // `0000000000000000000000000000000000000000000000000000000000000000:123456`
+  // 
+  // `out_is` is a list of output indexes (within the creating transaction)
+  // for which addresses should be generated. At most 256 indexes are accepted
+  // per call.
   addresses : (text, text, vec nat32) -> (Result);
   config : () -> (Config) query;
   // Current cycle balance of this canister.

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -282,13 +282,13 @@ fn spell_to_hex(spell: NormalizedSpell) -> Result<String, String> {
 }
 
 #[ic_cdk::update]
-pub async fn address(network: String, tx_in_0: String, out_i: usize) -> Result<String, String> {
+pub async fn address(network: String, tx_in_0: String, out_i: u32) -> Result<String, String> {
     address_impl(network, tx_in_0, out_i)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn address_impl(network: String, tx_in_0: String, out_i: usize) -> anyhow::Result<String> {
+async fn address_impl(network: String, tx_in_0: String, out_i: u32) -> anyhow::Result<String> {
     let network = check_network(&network)?;
     let tx_in_0: UtxoId = tx_in_0
         .parse()
@@ -299,11 +299,11 @@ async fn address_impl(network: String, tx_in_0: String, out_i: usize) -> anyhow:
     Ok(address)
 }
 
-fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: usize) -> Vec<Vec<u8>> {
+fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: u32) -> Vec<Vec<u8>> {
     let tx_in_0_bytes = util::write(tx_in_0)
         .expect("UtxoId should always serialize");
     let out_i_bytes = util::write(&out_i)
-        .expect("usize should always serialize");
+        .expect("u32 should always serialize");
     vec![SCROLLS.to_vec(), tx_in_0_bytes, out_i_bytes]
 }
 
@@ -316,7 +316,7 @@ fn key_id() -> EcdsaKeyId {
 
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
 pub struct SignRequest {
-    sign_inputs: Vec<usize>,
+    sign_inputs: Vec<u32>,
     prev_txs: Vec<String>,
     tx_to_sign: String,
 }
@@ -391,18 +391,19 @@ async fn do_sign(
 /// Bounds and duplicate detection happen first so that an out-of-range or
 /// repeated `sign_inputs` index produces an accurate error message instead of
 /// a misleading "input N has no witness" report.
-fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[usize]) -> anyhow::Result<()> {
+fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[u32]) -> anyhow::Result<()> {
     let input_count = tx.input.len();
     let mut signing: HashSet<usize> = HashSet::new();
     for &idx in sign_inputs {
+        let idx_usize = idx as usize;
         ensure!(
-            idx < input_count,
+            idx_usize < input_count,
             "Input error: input_index {} is out of range [0, {})",
             idx,
             input_count
         );
         ensure!(
-            signing.insert(idx),
+            signing.insert(idx_usize),
             "Input error: duplicate input_index: {}",
             idx
         );
@@ -534,14 +535,15 @@ fn configured_fee_script_pubkey(network: Network) -> ScriptBuf {
 }
 
 async fn sign_tx(
-    sign_inputs: Vec<usize>,
+    sign_inputs: Vec<u32>,
     prev_txs: &BTreeMap<Txid, Transaction>,
     mut bitcoin_tx: Transaction,
 ) -> anyhow::Result<Transaction> {
     for input_index in sign_inputs {
+        let input_index_usize = input_index as usize;
         let out_point = bitcoin_tx
             .input
-            .get(input_index)
+            .get(input_index_usize)
             .ok_or_else(|| anyhow!("Input error: invalid input_index: {}", input_index))?
             .previous_output;
 
@@ -559,7 +561,7 @@ async fn sign_tx(
 
         let first_in = &creating_tx.input[0].previous_output;
         let tx_in_0 = UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout);
-        let out_i = out_point.vout as usize;
+        let out_i = out_point.vout;
 
         let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
 
@@ -577,12 +579,12 @@ async fn sign_tx(
         let value = tx_out.value;
 
         let tx_sighash = SighashCache::new(&bitcoin_tx)
-            .p2wpkh_signature_hash(input_index, script_pubkey, value, EcdsaSighashType::All)
+            .p2wpkh_signature_hash(input_index_usize, script_pubkey, value, EcdsaSighashType::All)
             .map_err(|e| anyhow!("System error: computing sighash: {}", e))?;
 
         let ecdsa_signature = sign_tx_sighash_for_output(&tx_in_0, out_i, &tx_sighash).await?;
 
-        let witness = &mut bitcoin_tx.input[input_index].witness;
+        let witness = &mut bitcoin_tx.input[input_index_usize].witness;
         witness.push_ecdsa_signature(&ecdsa_signature);
         witness.push(&public_key.to_bytes());
     }
@@ -613,7 +615,7 @@ async fn sign_tx_sighash_with_path(
 
 async fn sign_tx_sighash_for_output(
     tx_in_0: &UtxoId,
-    out_i: usize,
+    out_i: u32,
     tx_sighash: &SegwitV0Sighash,
 ) -> anyhow::Result<Signature> {
     sign_tx_sighash_with_path(derivation_path_for_output(tx_in_0, out_i), tx_sighash).await
@@ -637,7 +639,7 @@ async fn derive_public_key_with_path(
 
 async fn derive_public_key_for_output(
     tx_in_0: &UtxoId,
-    out_i: usize,
+    out_i: u32,
 ) -> anyhow::Result<CompressedPublicKey> {
     derive_public_key_with_path(derivation_path_for_output(tx_in_0, out_i)).await
 }

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -9,7 +9,7 @@ use bitcoin::{
     sighash::SighashCache,
 };
 use candid::{CandidType, Principal};
-use charms_data::util;
+use charms_data::{util, TxId, UtxoId};
 use charms_lib::{
     CURRENT_VERSION, NormalizedSpell, SPELL_VK,
     bitcoin_tx::BitcoinTx,
@@ -29,7 +29,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
     str::FromStr,
-    string::ToString,
     sync::LazyLock,
 };
 
@@ -283,22 +282,29 @@ fn spell_to_hex(spell: NormalizedSpell) -> Result<String, String> {
 }
 
 #[ic_cdk::update]
-pub async fn address(network: String, nonce: u64) -> Result<String, String> {
-    address_impl(network, nonce)
+pub async fn address(network: String, tx_in_0: String, out_i: usize) -> Result<String, String> {
+    address_impl(network, tx_in_0, out_i)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn address_impl(network: String, nonce: u64) -> anyhow::Result<String> {
+async fn address_impl(network: String, tx_in_0: String, out_i: usize) -> anyhow::Result<String> {
     let network = check_network(&network)?;
-    let public_key = derive_public_key(nonce).await?;
+    let tx_in_0: UtxoId = tx_in_0
+        .parse()
+        .map_err(|e| anyhow!("Input error: invalid tx_in_0: {}", e))?;
+    let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
 
     let address = bitcoin::Address::p2wpkh(&public_key, network).to_string();
     Ok(address)
 }
 
-fn derivation_path(nonce: u64) -> Vec<Vec<u8>> {
-    vec![SCROLLS.to_vec(), nonce.to_le_bytes().to_vec()]
+fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: usize) -> Vec<Vec<u8>> {
+    let tx_in_0_bytes = util::write(tx_in_0)
+        .expect("UtxoId should always serialize");
+    let out_i_bytes = util::write(&out_i)
+        .expect("usize should always serialize");
+    vec![SCROLLS.to_vec(), tx_in_0_bytes, out_i_bytes]
 }
 
 fn key_id() -> EcdsaKeyId {
@@ -309,14 +315,8 @@ fn key_id() -> EcdsaKeyId {
 }
 
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
-pub struct SignInput {
-    pub index: usize,
-    pub nonce: u64,
-}
-
-#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
 pub struct SignRequest {
-    sign_inputs: Vec<SignInput>,
+    sign_inputs: Vec<usize>,
     prev_txs: Vec<String>,
     tx_to_sign: String,
 }
@@ -391,11 +391,10 @@ async fn do_sign(
 /// Bounds and duplicate detection happen first so that an out-of-range or
 /// repeated `sign_inputs` index produces an accurate error message instead of
 /// a misleading "input N has no witness" report.
-fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[SignInput]) -> anyhow::Result<()> {
+fn check_existing_witnesses(tx: &Transaction, sign_inputs: &[usize]) -> anyhow::Result<()> {
     let input_count = tx.input.len();
     let mut signing: HashSet<usize> = HashSet::new();
-    for sign_input in sign_inputs {
-        let idx = sign_input.index;
+    for &idx in sign_inputs {
         ensure!(
             idx < input_count,
             "Input error: input_index {} is out of range [0, {})",
@@ -535,24 +534,36 @@ fn configured_fee_script_pubkey(network: Network) -> ScriptBuf {
 }
 
 async fn sign_tx(
-    sign_inputs: Vec<SignInput>,
+    sign_inputs: Vec<usize>,
     prev_txs: &BTreeMap<Txid, Transaction>,
     mut bitcoin_tx: Transaction,
 ) -> anyhow::Result<Transaction> {
-    for sign_input in sign_inputs {
-        let input_index = sign_input.index;
-        let nonce = sign_input.nonce;
-
-        let public_key = derive_public_key(nonce).await?;
-
+    for input_index in sign_inputs {
         let out_point = bitcoin_tx
             .input
             .get(input_index)
             .ok_or_else(|| anyhow!("Input error: invalid input_index: {}", input_index))?
             .previous_output;
-        let tx_out = prev_txs
+
+        // The UTXO we are spending was created as output `out_point.vout` in `prev_tx`.
+        // Its controlling key was derived from (first input of that prev_tx, output index).
+        let creating_tx = prev_txs
             .get(&out_point.txid)
-            .ok_or_else(|| anyhow!("Input error: missing prev_tx with txid: {}", out_point.txid))?
+            .ok_or_else(|| anyhow!("Input error: missing prev_tx with txid: {}", out_point.txid))?;
+
+        ensure!(
+            !creating_tx.input.is_empty(),
+            "Input error: prev_tx {} has no inputs; cannot derive address path",
+            out_point.txid
+        );
+
+        let first_in = &creating_tx.input[0].previous_output;
+        let tx_in_0 = UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout);
+        let out_i = out_point.vout as usize;
+
+        let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
+
+        let tx_out = creating_tx
             .output
             .get(out_point.vout as usize)
             .ok_or_else(|| {
@@ -569,7 +580,7 @@ async fn sign_tx(
             .p2wpkh_signature_hash(input_index, script_pubkey, value, EcdsaSighashType::All)
             .map_err(|e| anyhow!("System error: computing sighash: {}", e))?;
 
-        let ecdsa_signature = sign_tx_sighash(nonce, &tx_sighash).await?;
+        let ecdsa_signature = sign_tx_sighash_for_output(&tx_in_0, out_i, &tx_sighash).await?;
 
         let witness = &mut bitcoin_tx.input[input_index].witness;
         witness.push_ecdsa_signature(&ecdsa_signature);
@@ -578,11 +589,14 @@ async fn sign_tx(
     Ok(bitcoin_tx)
 }
 
-async fn sign_tx_sighash(nonce: u64, tx_sighash: &SegwitV0Sighash) -> anyhow::Result<Signature> {
+async fn sign_tx_sighash_with_path(
+    derivation_path: Vec<Vec<u8>>,
+    tx_sighash: &SegwitV0Sighash,
+) -> anyhow::Result<Signature> {
     let message_hash = tx_sighash.to_byte_array().to_vec();
     let sign_with_ecdsa_arg = SignWithEcdsaArgs {
         message_hash,
-        derivation_path: derivation_path(nonce),
+        derivation_path,
         key_id: key_id(),
     };
     let sign_result = sign_with_ecdsa(&sign_with_ecdsa_arg)
@@ -597,10 +611,20 @@ async fn sign_tx_sighash(nonce: u64, tx_sighash: &SegwitV0Sighash) -> anyhow::Re
     Ok(ecdsa_signature)
 }
 
-async fn derive_public_key(nonce: u64) -> anyhow::Result<CompressedPublicKey> {
+async fn sign_tx_sighash_for_output(
+    tx_in_0: &UtxoId,
+    out_i: usize,
+    tx_sighash: &SegwitV0Sighash,
+) -> anyhow::Result<Signature> {
+    sign_tx_sighash_with_path(derivation_path_for_output(tx_in_0, out_i), tx_sighash).await
+}
+
+async fn derive_public_key_with_path(
+    derivation_path: Vec<Vec<u8>>,
+) -> anyhow::Result<CompressedPublicKey> {
     let ecdsa_public_key_args = EcdsaPublicKeyArgs {
         canister_id: None,
-        derivation_path: derivation_path(nonce),
+        derivation_path,
         key_id: key_id(),
     };
     let ecdsa_public_key_result = ecdsa_public_key(&ecdsa_public_key_args)
@@ -609,6 +633,13 @@ async fn derive_public_key(nonce: u64) -> anyhow::Result<CompressedPublicKey> {
     let public_key = CompressedPublicKey::from_slice(&ecdsa_public_key_result.public_key)
         .map_err(|e| anyhow!("System error: parsing user public key: {}", e))?;
     Ok(public_key)
+}
+
+async fn derive_public_key_for_output(
+    tx_in_0: &UtxoId,
+    out_i: usize,
+) -> anyhow::Result<CompressedPublicKey> {
+    derive_public_key_with_path(derivation_path_for_output(tx_in_0, out_i)).await
 }
 
 fn txid_to_tx(

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, anyhow, bail, ensure};
 use bitcoin::{
     Address, CompressedPublicKey, EcdsaSighashType, Network, ScriptBuf, SegwitV0Sighash,
-    Transaction, Txid,
+    Transaction, TxIn, Txid,
     consensus::encode::{deserialize_hex, serialize},
     ecdsa::Signature,
     hashes::Hash,
@@ -9,7 +9,7 @@ use bitcoin::{
     sighash::SighashCache,
 };
 use candid::{CandidType, Principal};
-use charms_data::{util, TxId, UtxoId};
+use charms_data::{TxId, UtxoId, util};
 use charms_lib::{
     CURRENT_VERSION, NormalizedSpell, SPELL_VK,
     bitcoin_tx::BitcoinTx,
@@ -282,13 +282,36 @@ fn spell_to_hex(spell: NormalizedSpell) -> Result<String, String> {
 }
 
 #[ic_cdk::update]
-pub async fn addresses(network: String, tx_in_0: String, out_is: Vec<u32>) -> Result<Vec<String>, String> {
+/// Returns Scroll-controlled P2WPKH addresses for the given network and derivation anchor.
+///
+/// `tx_in_0` is a string of the form `txid_hex:vout` (or block height for coinbase).
+/// It identifies the unique "anchor" used for key derivation:
+///
+/// * For a normal (non-coinbase) output, this is the outpoint (`{txid}:{vout}`) of the *first
+///   input* of the transaction that created the output(s) being addressed.
+/// * For an output created by a **coinbase** transaction, use the all-zeros txid (the txid that
+///   appears as the first input's `txid` of the coinbase transaction itself) together with the
+///   block height (as a decimal integer) in place of the vout. Example:
+///   `0000000000000000000000000000000000000000000000000000000000000000:123456`
+///
+/// `out_is` is a list of output indexes (within the creating transaction)
+/// for which addresses should be generated. At most 256 indexes are accepted
+/// per call.
+pub async fn addresses(
+    network: String,
+    tx_in_0: String,
+    out_is: Vec<u32>,
+) -> Result<Vec<String>, String> {
     addresses_impl(network, tx_in_0, out_is)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn addresses_impl(network: String, tx_in_0: String, out_is: Vec<u32>) -> anyhow::Result<Vec<String>> {
+async fn addresses_impl(
+    network: String,
+    tx_in_0: String,
+    out_is: Vec<u32>,
+) -> anyhow::Result<Vec<String>> {
     ensure!(
         out_is.len() <= 256,
         "Input error: too many output indexes requested (max: 256)"
@@ -309,10 +332,10 @@ async fn addresses_impl(network: String, tx_in_0: String, out_is: Vec<u32>) -> a
 }
 
 fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: u32) -> anyhow::Result<Vec<Vec<u8>>> {
-    let tx_in_0_bytes = util::write(tx_in_0)
-        .context("System error: serializing tx_in_0 for derivation path")?;
-    let out_i_bytes = util::write(&out_i)
-        .context("System error: serializing out_i for derivation path")?;
+    let tx_in_0_bytes =
+        util::write(tx_in_0).context("System error: serializing tx_in_0 for derivation path")?;
+    let out_i_bytes =
+        util::write(&out_i).context("System error: serializing out_i for derivation path")?;
     Ok(vec![SCROLLS.to_vec(), tx_in_0_bytes, out_i_bytes])
 }
 
@@ -535,6 +558,18 @@ fn signable_inputs(tx: &Transaction) -> usize {
     tx.input.len()
 }
 
+/// Extract the block height from a coinbase input's scriptSig.
+/// The caller must pass `&tx.input[0]` of a coinbase transaction (i.e. after checking `tx.is_coinbase()`).
+/// Returns `None` if the height could not be parsed.
+fn extract_coinbase_height(coinbase_input: &TxIn) -> Option<u32> {
+    let push = coinbase_input.script_sig.instructions_minimal().next()?.ok()?;
+    let bitcoin::script::Instruction::PushBytes(b) = push else {
+        return None;
+    };
+    let h = bitcoin::script::read_scriptint(b.as_bytes()).ok()?;
+    u32::try_from(h).ok()
+}
+
 fn configured_fee_script_pubkey(network: Network) -> ScriptBuf {
     let expected_fee_script_pubkey = Address::from_str(&CONFIG.fee_address[network.to_core_arg()])
         .unwrap()
@@ -558,6 +593,7 @@ async fn sign_tx(
 
         // The UTXO we are spending was created as output `out_point.vout` in `prev_tx`.
         // Its controlling key was derived from (first input of that prev_tx, output index).
+        // For coinbase-created outputs we instead use (coinbase_txid, block_height).
         let creating_tx = prev_txs
             .get(&out_point.txid)
             .ok_or_else(|| anyhow!("Input error: missing prev_tx with txid: {}", out_point.txid))?;
@@ -569,13 +605,18 @@ async fn sign_tx(
         );
 
         let first_in = &creating_tx.input[0].previous_output;
-        ensure!(
-            first_in.txid != bitcoin::Txid::all_zeros(),
-            "Input error: prev_tx {} is a coinbase transaction; coinbase-created outputs cannot be used as derivation anchors",
-            out_point.txid
-        );
 
-        let tx_in_0 = UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout);
+        let tx_in_0 = if creating_tx.is_coinbase() {
+            let height = extract_coinbase_height(&creating_tx.input[0]).ok_or_else(|| {
+                anyhow!(
+                    "Input error: could not extract block height from coinbase {}",
+                    out_point.txid
+                )
+            })?;
+            UtxoId(TxId(first_in.txid.to_byte_array()), height)
+        } else {
+            UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout)
+        };
         let out_i = out_point.vout;
 
         let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
@@ -592,7 +633,8 @@ async fn sign_tx(
             })?;
 
         // Verify that the output actually pays to the key we just derived.
-        // This prevents wasting an expensive threshold ECDSA call on malformed/adversarial prev_txs.
+        // This prevents wasting an expensive threshold ECDSA call on malformed/adversarial
+        // prev_txs.
         let hash = bitcoin::hashes::hash160::Hash::hash(&public_key.to_bytes());
         let pubkey_hash = bitcoin::WPubkeyHash::from_byte_array(hash.to_byte_array());
         let expected_spk = bitcoin::ScriptBuf::new_p2wpkh(&pubkey_hash);
@@ -606,7 +648,12 @@ async fn sign_tx(
         let value = tx_out.value;
 
         let tx_sighash = SighashCache::new(&bitcoin_tx)
-            .p2wpkh_signature_hash(input_index_usize, script_pubkey, value, EcdsaSighashType::All)
+            .p2wpkh_signature_hash(
+                input_index_usize,
+                script_pubkey,
+                value,
+                EcdsaSighashType::All,
+            )
             .map_err(|e| anyhow!("System error: computing sighash: {}", e))?;
 
         let ecdsa_signature = sign_tx_sighash_for_output(&tx_in_0, out_i, &tx_sighash).await?;

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -289,6 +289,11 @@ pub async fn addresses(network: String, tx_in_0: String, out_is: Vec<u32>) -> Re
 }
 
 async fn addresses_impl(network: String, tx_in_0: String, out_is: Vec<u32>) -> anyhow::Result<Vec<String>> {
+    ensure!(
+        out_is.len() <= 256,
+        "Input error: too many output indexes requested (max: 256)"
+    );
+
     let network = check_network(&network)?;
     let tx_in_0: UtxoId = tx_in_0
         .parse()
@@ -303,12 +308,12 @@ async fn addresses_impl(network: String, tx_in_0: String, out_is: Vec<u32>) -> a
     Ok(addresses)
 }
 
-fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: u32) -> Vec<Vec<u8>> {
+fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: u32) -> anyhow::Result<Vec<Vec<u8>>> {
     let tx_in_0_bytes = util::write(tx_in_0)
-        .expect("UtxoId should always serialize");
+        .context("System error: serializing tx_in_0 for derivation path")?;
     let out_i_bytes = util::write(&out_i)
-        .expect("u32 should always serialize");
-    vec![SCROLLS.to_vec(), tx_in_0_bytes, out_i_bytes]
+        .context("System error: serializing out_i for derivation path")?;
+    Ok(vec![SCROLLS.to_vec(), tx_in_0_bytes, out_i_bytes])
 }
 
 fn key_id() -> EcdsaKeyId {
@@ -564,6 +569,12 @@ async fn sign_tx(
         );
 
         let first_in = &creating_tx.input[0].previous_output;
+        ensure!(
+            first_in.txid != bitcoin::Txid::all_zeros(),
+            "Input error: prev_tx {} is a coinbase transaction; coinbase-created outputs cannot be used as derivation anchors",
+            out_point.txid
+        );
+
         let tx_in_0 = UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout);
         let out_i = out_point.vout;
 
@@ -579,6 +590,18 @@ async fn sign_tx(
                     out_point.vout
                 )
             })?;
+
+        // Verify that the output actually pays to the key we just derived.
+        // This prevents wasting an expensive threshold ECDSA call on malformed/adversarial prev_txs.
+        let hash = bitcoin::hashes::hash160::Hash::hash(&public_key.to_bytes());
+        let pubkey_hash = bitcoin::WPubkeyHash::from_byte_array(hash.to_byte_array());
+        let expected_spk = bitcoin::ScriptBuf::new_p2wpkh(&pubkey_hash);
+        ensure!(
+            &tx_out.script_pubkey == &expected_spk,
+            "Input error: output script in prev_tx {} does not match the derived public key",
+            out_point.txid
+        );
+
         let script_pubkey = &tx_out.script_pubkey;
         let value = tx_out.value;
 
@@ -622,7 +645,7 @@ async fn sign_tx_sighash_for_output(
     out_i: u32,
     tx_sighash: &SegwitV0Sighash,
 ) -> anyhow::Result<Signature> {
-    sign_tx_sighash_with_path(derivation_path_for_output(tx_in_0, out_i), tx_sighash).await
+    sign_tx_sighash_with_path(derivation_path_for_output(tx_in_0, out_i)?, tx_sighash).await
 }
 
 async fn derive_public_key_with_path(
@@ -645,7 +668,7 @@ async fn derive_public_key_for_output(
     tx_in_0: &UtxoId,
     out_i: u32,
 ) -> anyhow::Result<CompressedPublicKey> {
-    derive_public_key_with_path(derivation_path_for_output(tx_in_0, out_i)).await
+    derive_public_key_with_path(derivation_path_for_output(tx_in_0, out_i)?).await
 }
 
 fn txid_to_tx(

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -282,21 +282,25 @@ fn spell_to_hex(spell: NormalizedSpell) -> Result<String, String> {
 }
 
 #[ic_cdk::update]
-pub async fn address(network: String, tx_in_0: String, out_i: u32) -> Result<String, String> {
-    address_impl(network, tx_in_0, out_i)
+pub async fn addresses(network: String, tx_in_0: String, out_is: Vec<u32>) -> Result<Vec<String>, String> {
+    addresses_impl(network, tx_in_0, out_is)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn address_impl(network: String, tx_in_0: String, out_i: u32) -> anyhow::Result<String> {
+async fn addresses_impl(network: String, tx_in_0: String, out_is: Vec<u32>) -> anyhow::Result<Vec<String>> {
     let network = check_network(&network)?;
     let tx_in_0: UtxoId = tx_in_0
         .parse()
         .map_err(|e| anyhow!("Input error: invalid tx_in_0: {}", e))?;
-    let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
 
-    let address = bitcoin::Address::p2wpkh(&public_key, network).to_string();
-    Ok(address)
+    let mut addresses = Vec::with_capacity(out_is.len());
+    for out_i in out_is {
+        let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
+        let address = bitcoin::Address::p2wpkh(&public_key, network).to_string();
+        addresses.push(address);
+    }
+    Ok(addresses)
 }
 
 fn derivation_path_for_output(tx_in_0: &UtxoId, out_i: u32) -> Vec<Vec<u8>> {

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -591,67 +591,61 @@ async fn sign_tx(
             .ok_or_else(|| anyhow!("Input error: invalid input_index: {}", input_index))?
             .previous_output;
 
-        // The UTXO we are spending was created as output `out_point.vout` in `prev_tx`.
-        // Its controlling key was derived from (first input of that prev_tx, output index).
+        // The UTXO we are spending was created as output `out_point.vout` in `creating_tx`.
+        // Its controlling key was derived from (first input of that creating_tx, output index).
         // For coinbase-created outputs we instead use (coinbase_txid, block_height).
         let creating_tx = prev_txs
             .get(&out_point.txid)
             .ok_or_else(|| anyhow!("Input error: missing prev_tx with txid: {}", out_point.txid))?;
 
-        ensure!(
-            !creating_tx.input.is_empty(),
-            "Input error: prev_tx {} has no inputs; cannot derive address path",
-            out_point.txid
-        );
+        let first_in = creating_tx.input.first().ok_or_else(|| {
+            anyhow!(
+                "Input error: prev_tx {} has no inputs; cannot derive address path",
+                out_point.txid
+            )
+        })?;
 
-        let first_in = &creating_tx.input[0].previous_output;
-
-        let tx_in_0 = if creating_tx.is_coinbase() {
-            let height = extract_coinbase_height(&creating_tx.input[0]).ok_or_else(|| {
+        let second_field = if creating_tx.is_coinbase() {
+            extract_coinbase_height(first_in).ok_or_else(|| {
                 anyhow!(
                     "Input error: could not extract block height from coinbase {}",
                     out_point.txid
                 )
-            })?;
-            UtxoId(TxId(first_in.txid.to_byte_array()), height)
+            })?
         } else {
-            UtxoId(TxId(first_in.txid.to_byte_array()), first_in.vout)
+            first_in.previous_output.vout
         };
+        let tx_in_0 = UtxoId(
+            TxId(first_in.previous_output.txid.to_byte_array()),
+            second_field,
+        );
         let out_i = out_point.vout;
 
         let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
 
-        let tx_out = creating_tx
-            .output
-            .get(out_point.vout as usize)
-            .ok_or_else(|| {
-                anyhow!(
-                    "Input error: prev_tx {} missing output with index: {}",
-                    out_point.txid,
-                    out_point.vout
-                )
-            })?;
+        let tx_out = creating_tx.output.get(out_i as usize).ok_or_else(|| {
+            anyhow!(
+                "Input error: prev_tx {} missing output with index: {}",
+                out_point.txid,
+                out_i
+            )
+        })?;
 
         // Verify that the output actually pays to the key we just derived.
         // This prevents wasting an expensive threshold ECDSA call on malformed/adversarial
         // prev_txs.
-        let hash = bitcoin::hashes::hash160::Hash::hash(&public_key.to_bytes());
-        let pubkey_hash = bitcoin::WPubkeyHash::from_byte_array(hash.to_byte_array());
-        let expected_spk = bitcoin::ScriptBuf::new_p2wpkh(&pubkey_hash);
+        let expected_spk = ScriptBuf::new_p2wpkh(&public_key.wpubkey_hash());
         ensure!(
-            &tx_out.script_pubkey == &expected_spk,
+            tx_out.script_pubkey == expected_spk,
             "Input error: output script in prev_tx {} does not match the derived public key",
             out_point.txid
         );
 
-        let script_pubkey = &tx_out.script_pubkey;
-        let value = tx_out.value;
-
         let tx_sighash = SighashCache::new(&bitcoin_tx)
             .p2wpkh_signature_hash(
                 input_index_usize,
-                script_pubkey,
-                value,
+                &tx_out.script_pubkey,
+                tx_out.value,
                 EcdsaSighashType::All,
             )
             .map_err(|e| anyhow!("System error: computing sighash: {}", e))?;


### PR DESCRIPTION
### Summary

This PR refactors address derivation in the `scrolls_bitcoin` canister (used for threshold ECDSA signing of Charms transactions on Bitcoin).

#### Key changes

- **New deterministic derivation scheme**: Addresses are now derived from `(first input of the creating tx, output index)` instead of a client-chosen `nonce`.
  - Derivation path: `["scrolls", cbor(tx_in_0), cbor(out_i)]`
  - This is computed on the canister side when signing, using the `prev_txs` already supplied in `sign_and_submit`.

- **Simplified signing API**:
  - `SignRequest.sign_inputs` is now just `Vec<u32>` (input indices).
  - The old `SignInput { index, nonce }` wrapper is removed.
  - The canister recovers the correct derivation data directly from the first input of each UTXO's creating transaction.

- **Generalized address endpoint**:
  - Renamed `address(...)` → `addresses(...)`.
  - Now accepts multiple output indexes (`Vec<u32>`) and returns multiple addresses (`Vec<String>`).

- **Type changes for Candid**:
  - Output indices are now `u32` / `nat32` everywhere (instead of `usize`).

- Dead nonce-based derivation code has been removed.

### Motivation

The previous nonce-based scheme required clients to remember and transmit nonces for every UTXO they might later spend. The new scheme makes address derivation a pure function of the transaction graph, which is simpler, safer, and easier to implement correctly in the Charms prover / client.

### Testing

- Compiles cleanly.
- No unit tests in this crate (integration tests live elsewhere and will be updated separately).

### Files changed

- `scrolls/src/scrolls_bitcoin/src/lib.rs`
- `scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did`

---

This is a breaking change to the canister interface and will require coordinated updates in the Charms client / prover and the Cloudflare `scrolls-api` worker.