### PR TITLE
Add SCROLLS_ADDRS_PUBKEY const with ic-pub-key derivation test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array 0.14.9",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +506,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2383,6 +2418,7 @@ dependencies = [
  "enum_dispatch",
  "hex",
  "hex-literal 1.1.0",
+ "ic-pub-key",
  "pallas-crypto 1.0.0",
  "proptest",
  "proptest-derive",
@@ -2487,6 +2523,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half 2.7.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
 ]
 
 [[package]]
@@ -2933,6 +2979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.9",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2950,6 +2997,15 @@ name = "cryptoxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ctutils"
@@ -3004,12 +3060,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3028,11 +3108,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3960,6 +4051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,7 +4500,7 @@ dependencies = [
  "k256",
  "leb128",
  "p256",
- "pem",
+ "pem 3.0.6",
  "pkcs8",
  "rand 0.10.1",
  "rangemap",
@@ -4416,6 +4517,49 @@ dependencies = [
  "tokio",
  "tower-service",
  "url",
+]
+
+[[package]]
+name = "ic-cdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818d6d5416a8f0212e1b132703b0da51e36c55f2b96677e96f2bbe7702e1bd85"
+dependencies = [
+ "candid",
+ "ic-cdk-executor",
+ "ic-cdk-macros",
+ "ic-error-types",
+ "ic-management-canister-types",
+ "ic0",
+ "pin-project-lite",
+ "serde",
+ "serde_bytes",
+ "slotmap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ic-cdk-executor"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33716b730ded33690b8a704bff3533fda87d229e58046823647d28816e9bcee7"
+dependencies = [
+ "ic0",
+ "slotmap",
+ "smallvec",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dad91a214945cb3605bc9ef6901b87e2ac41e3624284c2cabba49d43aa4f43"
+dependencies = [
+ "candid",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4441,10 +4585,72 @@ dependencies = [
  "hex-literal 0.4.1",
  "hkdf",
  "ic_principal",
- "pem",
+ "pem 3.0.6",
  "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
+]
+
+[[package]]
+name = "ic-error-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbeeb3d91aa179d6496d7293becdacedfc413c825cac79fd54ea1906f003ee55"
+dependencies = [
+ "serde",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "ic-management-canister-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3149217e24186df3f13dc45eee14cdb3e5cad07d0b2b67bd53555c1c55462957"
+dependencies = [
+ "candid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-pub-key"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16679102978cada1ced7a8902f9898bf4f4330de3c058c304658cc1cd35470cb"
+dependencies = [
+ "ic-ed25519",
+ "ic-management-canister-types",
+ "ic-secp256k1",
+ "ic-vetkeys",
+]
+
+[[package]]
+name = "ic-secp256k1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf34836f1c4e8114b6d13b7699428939742e9ad73615bc0be4799ccc5566869"
+dependencies = [
+ "hex-literal 0.4.1",
+ "hmac 0.12.1",
+ "ic_principal",
+ "k256",
+ "num-bigint 0.4.6",
+ "pem 1.1.1",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.9",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee3372ddc0cf2a747fc26ce2d075a240ed6bfab151e63bc70109e8967f7ce6f"
+dependencies = [
+ "ic_principal",
 ]
 
 [[package]]
@@ -4480,6 +4686,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-vetkeys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc87ee136e49cc95d9883d2b2c4fedadd6b286b17dd90ce531e7c56ebc36dc6e"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "candid",
+ "futures",
+ "hex-literal 1.1.0",
+ "hkdf",
+ "ic-cdk",
+ "ic-stable-structures",
+ "ic_bls12_381",
+ "lazy_static",
+ "pairing 0.23.0",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "sha2 0.10.9",
+ "sha3",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ic0"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77c8932bff1f09502d0d8c079d5a206a06afe523e35e816162cf4d30b5bf80d"
+
+[[package]]
 name = "ic_bls12_381"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +4733,7 @@ dependencies = [
  "pairing 0.23.0",
  "rand_core 0.6.4",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4682,6 +4925,15 @@ dependencies = [
  "portable-atomic",
  "unicode-width 0.2.2",
  "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array 0.14.9",
 ]
 
 [[package]]
@@ -6216,6 +6468,15 @@ checksum = "7011d97b484a5ebdc4b1fdb3b12d5e4bbbea56e9d22b688f2e79e04b65a7d8a6"
 
 [[package]]
 name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
@@ -6330,6 +6591,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -7686,7 +7959,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7869,6 +8142,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -8311,6 +8596,15 @@ dependencies = [
  "slop-tensor",
  "slop-utils",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -9997,6 +10291,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/charms-client/Cargo.toml
+++ b/charms-client/Cargo.toml
@@ -43,6 +43,7 @@ uplc = { version = "1.1.21" }
 [dev-dependencies]
 charms-data = { path = "../charms-data", version = "15.0.0", features = ["test"] }
 ciborium = { workspace = true }
+ic-pub-key = "0.3.0"
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }

--- a/charms-client/src/bitcoin_tx.rs
+++ b/charms-client/src/bitcoin_tx.rs
@@ -401,7 +401,7 @@ mod tests {
     fn scrolls_addrs_pubkey_is_the_one_derived_for_icp_threshold_schnorr() {
         use ic_pub_key::{derive_schnorr_key, CanisterId, SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgs};
 
-        // Canister ID bytes for rpgc6-oqaaa-aaaak-qy3uq-cai (obtained via Principal::from_text)
+        // Textual canister ID for rpgc6-oqaaa-aaaak-qy3uq-cai.
         let canister_id = CanisterId::from_str("rpgc6-oqaaa-aaaak-qy3uq-cai").unwrap();
 
         let args = SchnorrPublicKeyArgs {
@@ -418,6 +418,7 @@ mod tests {
         // The crate (and the live management canister) returns the Schnorr public key
         // in SEC1 compressed form (33 bytes, 0x02/0x03 prefix + 32-byte x coord).
         // SCROLLS_ADDRS_PUBKEY stores the 32-byte x-only form used for BIP-340 verification.
+        assert_eq!(result.public_key.len(), 33, "expected 33-byte SEC1 compressed key");
         let derived_x_only: [u8; 32] = result.public_key[1..].try_into().unwrap();
 
         assert_eq!(SCROLLS_ADDRS_PUBKEY, derived_x_only);

--- a/charms-client/src/bitcoin_tx.rs
+++ b/charms-client/src/bitcoin_tx.rs
@@ -176,6 +176,18 @@ impl EnchantedTx for BitcoinTx {
 
 pub const FINALITY_TARGET_BITS: u32 = 0x16507000; // mainnet finality target bits (~6 blocks)
 
+/// The 32-byte BIP-340 (x-only) secp256k1 public key corresponding to the
+/// threshold Schnorr key held by the ICP subnet for the `scrolls_bitcoin_v15`
+/// canister (`rpgc6-oqaaa-aaaak-qy3uq-cai`), under the derivation path `[b"sign"]`
+/// and key_id `("key_1", bip340secp256k1)`.
+///
+/// This value is obtained (and the const is validated at test time) via the
+/// offline equivalent `ic_pub_key::derive_schnorr_key` (or the live management
+/// canister `schnorr_public_key` call). It is used by the client to verify the
+/// Schnorr signature returned by the canister's `addresses(...)` endpoint.
+pub const SCROLLS_ADDRS_PUBKEY: [u8; 32] =
+    hex_literal::hex!("30109b1c3c8dc1812de6267cd864a5f1f794330c6e43c25f971e6d0ae9440e3b");
+
 fn verify_finality_proof(
     tx: &Transaction,
     tx_block_proof: &MerkleBlock,
@@ -351,6 +363,7 @@ pub fn parse_spell_and_proof_from_witness(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use super::*;
 
     fn compute_finality_target(target_bits: u32) -> CompactTarget {
@@ -382,5 +395,31 @@ mod tests {
 
         let required_work = finality_target.to_work();
         assert!(dbg!(cumulative_work) >= dbg!(required_work));
+    }
+
+    #[test]
+    fn scrolls_addrs_pubkey_is_the_one_derived_for_icp_threshold_schnorr() {
+        use ic_pub_key::{derive_schnorr_key, CanisterId, SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgs};
+
+        // Canister ID bytes for rpgc6-oqaaa-aaaak-qy3uq-cai (obtained via Principal::from_text)
+        let canister_id = CanisterId::from_str("rpgc6-oqaaa-aaaak-qy3uq-cai").unwrap();
+
+        let args = SchnorrPublicKeyArgs {
+            canister_id: Some(canister_id),
+            derivation_path: vec![b"sign".to_vec()],
+            key_id: SchnorrKeyId {
+                algorithm: SchnorrAlgorithm::Bip340secp256k1,
+                name: "key_1".to_string(),
+            },
+        };
+
+        let result = derive_schnorr_key(&args).expect("derivation must succeed for mainnet key_1");
+
+        // The crate (and the live management canister) returns the Schnorr public key
+        // in SEC1 compressed form (33 bytes, 0x02/0x03 prefix + 32-byte x coord).
+        // SCROLLS_ADDRS_PUBKEY stores the 32-byte x-only form used for BIP-340 verification.
+        let derived_x_only: [u8; 32] = result.public_key[1..].try_into().unwrap();
+
+        assert_eq!(SCROLLS_ADDRS_PUBKEY, derived_x_only);
     }
 }


### PR DESCRIPTION
This PR introduces `SCROLLS_ADDRS_PUBKEY`, the 32-byte x-only BIP-340 secp256k1 public key used by the `scrolls_bitcoin_v15` canister (`rpgc6-oqaaa-aaaak-qy3uq-cai`) under the fixed derivation path `[b"sign"]` (key_id `("key_1", bip340secp256k1)`) to sign responses from its `addresses(...)` endpoint.

Changes:
- Added `ic-pub-key = "0.3.0"` as a dev-dependency in `charms-client`
- Defined `SCROLLS_ADDRS_PUBKEY` using the `hex!` macro (via `hex_literal`)
- Added a self-checking test that calls `ic_pub_key::derive_schnorr_key` at runtime with the exact canister + derivation path and asserts equality against the const

This allows the client to verify Scrolls-signed address maps offline using the pinned public key.