### PR TITLE
feat(charms-client): add tx.scrolls output set + signed-address-map verification

### DIFF
--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -1,9 +1,13 @@
-use crate::tx::{EnchantedTx, Tx, by_txid, extended_normalized_spell};
-use anyhow::{Context, anyhow, ensure};
+use crate::{
+    bitcoin_tx::SCROLLS_ADDRS_PUBKEY,
+    tx::{EnchantedTx, Tx, by_txid, extended_normalized_spell},
+};
+use anyhow::{Context, anyhow, bail, ensure};
+use bitcoin::secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature};
 use charms_app_runner::AppRunner;
 use charms_data::{
-    App, AppInput, B32, Charms, Data, NativeOutput, TOKEN, Transaction, TxId, UtxoId, VersionedApp,
-    check, is_simple_transfer,
+    App, AppInput, B32, Charms, Data, NativeOutput, SCROLL, TOKEN, Transaction, TxId, UtxoId,
+    VersionedApp, check, is_simple_transfer, util,
 };
 use const_format::formatcp;
 use serde::{Deserialize, Serialize};
@@ -128,6 +132,20 @@ pub struct NormalizedTransaction {
     /// Amounts of native coin in transaction outputs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coins: Option<Vec<NativeOutput>>,
+
+    /// Indexes of outputs that MUST be sent to a Scrolls-managed address on Bitcoin.
+    ///
+    /// When non-empty on a Bitcoin spell, [`SpellProverInput::scrolls_addresses`] MUST
+    /// carry the signed `output_index -> address` map obtained by calling `addresses()`
+    /// on the `scrolls_bitcoin_v15` canister (passing the Bitcoin network — `"main"` or
+    /// `"testnet4"` — the spell's first input UTXO outpoint, and this set of indexes).
+    /// [`is_correct`] verifies the canister's BIP-340 Schnorr signature and that this
+    /// set equals the keys of the signed address map.
+    ///
+    /// Every spell-output containing a charm whose app has tag [`charms_data::SCROLL`]
+    /// MUST have its index listed here.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scrolls: Option<BTreeSet<u32>>,
 }
 
 impl NormalizedTransaction {
@@ -359,6 +377,17 @@ pub fn charms(spell: &NormalizedSpell, n_charms: &NormalizedCharms) -> Charms {
         .collect()
 }
 
+/// Output of the `scrolls_bitcoin_v15` canister's `addresses(...)` endpoint:
+/// a map from spell-output index to its derived P2WPKH address, plus a hex-encoded
+/// BIP-340 Schnorr signature over the CBOR serialization of the map, produced under
+/// the canister's chain key derivation path `[b"sign"]`. The signature is verified
+/// against [`crate::bitcoin_tx::SCROLLS_ADDRS_PUBKEY`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SignedScrollsAddresses {
+    pub addresses: BTreeMap<u32, String>,
+    pub signature: String,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpellProverInput {
     pub self_spell_vk: String,
@@ -366,6 +395,11 @@ pub struct SpellProverInput {
     pub spell: NormalizedSpell,
     pub tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
     pub app_input: Option<AppInput>,
+    /// Signed `output_index -> address` map for the spell's Scrolls outputs. MUST be
+    /// `Some` whenever the spell is on Bitcoin and [`NormalizedTransaction::scrolls`]
+    /// is non-empty. Verified inside [`is_correct`].
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scrolls_addresses: Option<SignedScrollsAddresses>,
 }
 
 /// Check if the spell is correct.
@@ -375,6 +409,7 @@ pub fn is_correct(
     app_input: Option<AppInput>,
     spell_vk: &str,
     tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
+    scrolls_addresses: Option<&SignedScrollsAddresses>,
 ) -> anyhow::Result<bool> {
     ensure!(beaming_txs_have_finality_proofs(
         prev_txs,
@@ -398,6 +433,10 @@ pub fn is_correct(
     ensure_no_orphan_versioned_apps(spell)?;
     check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
+    check_scroll_outputs_are_listed(spell)?;
+    if prev_txs.iter().any(|tx| matches!(tx, Tx::Bitcoin(_))) {
+        check_scrolls_addresses(spell, scrolls_addresses)?;
+    }
 
     let apps = apps(spell);
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
@@ -833,6 +872,78 @@ fn apps_satisfied(
         )
         .context("all apps should run successfully")?;
     Ok(())
+}
+
+/// Every output that carries a charm whose app has tag [`SCROLL`] MUST have its index
+/// listed in `spell.tx.scrolls`. The chain-conditional signature check lives in
+/// [`check_scrolls_addresses`]; this structural rule applies regardless of chain (on
+/// Cardano the SCROLL app behaves as a regular non-token app, but the index still has
+/// to be declared so the spell shape stays uniform across chains).
+fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()> {
+    let apps = apps(spell);
+    for (i, n_charm) in spell.tx.outs.iter().enumerate() {
+        let has_scroll = n_charm
+            .keys()
+            .any(|&app_i| apps[app_i as usize].tag == SCROLL);
+        if has_scroll {
+            let listed = spell
+                .tx
+                .scrolls
+                .as_ref()
+                .is_some_and(|s| s.contains(&(i as u32)));
+            ensure!(
+                listed,
+                "output #{} carries a SCROLL-tagged charm but is not listed in `tx.scrolls`",
+                i
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Verify the canister-signed Scrolls address map. Called only when the spell is on
+/// Bitcoin. When `spell.tx.scrolls` is non-empty, the signed map MUST be provided, its
+/// keys MUST equal `spell.tx.scrolls`, and its BIP-340 Schnorr signature MUST verify
+/// under [`SCROLLS_ADDRS_PUBKEY`] over `SHA-256(CBOR(addresses))` (the same digest the
+/// `scrolls_bitcoin_v15` canister signs).
+fn check_scrolls_addresses(
+    spell: &NormalizedSpell,
+    scrolls_addresses: Option<&SignedScrollsAddresses>,
+) -> anyhow::Result<()> {
+    let Some(scrolls) = spell.tx.scrolls.as_ref().filter(|s| !s.is_empty()) else {
+        return Ok(());
+    };
+    let Some(scrolls_addresses) = scrolls_addresses else {
+        bail!(
+            "Bitcoin spell declares {} Scrolls output(s) but no signed address map was provided",
+            scrolls.len()
+        );
+    };
+    let signed_keys: BTreeSet<u32> = scrolls_addresses.addresses.keys().copied().collect();
+    ensure!(
+        scrolls == &signed_keys,
+        "signed Scrolls address map keys ({:?}) do not match `tx.scrolls` ({:?})",
+        signed_keys,
+        scrolls
+    );
+    verify_scrolls_addresses_signature(scrolls_addresses)
+}
+
+fn verify_scrolls_addresses_signature(s: &SignedScrollsAddresses) -> anyhow::Result<()> {
+    let message_bytes =
+        util::write(&s.addresses).context("serializing Scrolls addresses for signature check")?;
+    let digest: [u8; 32] = Sha256::digest(&message_bytes).into();
+    let msg = Message::from_digest(digest);
+
+    let sig_bytes = hex::decode(&s.signature).context("decoding Scrolls signature hex")?;
+    let sig =
+        Signature::from_slice(&sig_bytes).context("parsing Scrolls BIP-340 Schnorr signature")?;
+    let pk = XOnlyPublicKey::from_slice(&SCROLLS_ADDRS_PUBKEY)
+        .context("parsing SCROLLS_ADDRS_PUBKEY as x-only secp256k1 key")?;
+
+    Secp256k1::verification_only()
+        .verify_schnorr(&sig, &msg, &pk)
+        .context("verifying Scrolls address-map Schnorr signature")
 }
 
 pub fn ensure_no_zero_amounts(norm_spell: &NormalizedSpell) -> anyhow::Result<()> {

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -437,7 +437,7 @@ pub fn is_correct(
     check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
     check_scroll_outputs_are_listed(spell)?;
-    if prev_txs.iter().any(|tx| matches!(tx, Tx::Bitcoin(_))) {
+    if hosting_chain_is_bitcoin(spell, prev_txs) {
         check_scroll_outputs(spell, scroll_outputs)?;
     }
 
@@ -877,12 +877,38 @@ fn apps_satisfied(
     Ok(())
 }
 
+/// The hosting tx's chain is the chain of the tx that created `spell.tx.ins[0]`. We
+/// can't just look at *any* `prev_txs` entry: beam-source txs are also in `prev_txs`
+/// and may live on a different chain than the hosting tx, so an `any(|t| Bitcoin)`
+/// would misfire on a Cardano spell with a Bitcoin beam source.
+fn hosting_chain_is_bitcoin(spell: &NormalizedSpell, prev_txs: &[Tx]) -> bool {
+    let Some(first_in) = spell.tx.ins.as_ref().and_then(|ins| ins.first()) else {
+        return false;
+    };
+    prev_txs
+        .iter()
+        .find(|tx| tx.tx_id() == first_in.0)
+        .is_some_and(|tx| matches!(tx, Tx::Bitcoin(_)))
+}
+
 /// Every output that carries a charm whose app has tag [`SCROLL`] MUST have its index
-/// listed in `spell.tx.scrolls`. The chain-conditional signature check lives in
-/// [`check_scroll_outputs`]; this structural rule applies regardless of chain (on
-/// Cardano the SCROLL app behaves as a regular non-token app, but the index still has
-/// to be declared so the spell shape stays uniform across chains).
+/// listed in `spell.tx.scrolls`, and every index in `spell.tx.scrolls` MUST point at a
+/// real spell output (`< spell.tx.outs.len()`). The chain-conditional signature check
+/// lives in [`check_scroll_outputs`]; these structural rules apply regardless of chain
+/// (on Cardano the SCROLL app behaves as a regular non-token app, but the index still
+/// has to be declared so the spell shape stays uniform across chains).
 fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()> {
+    let outs_len = spell.tx.outs.len() as u32;
+    if let Some(scrolls) = spell.tx.scrolls.as_ref() {
+        for &i in scrolls {
+            ensure!(
+                i < outs_len,
+                "`tx.scrolls` references output #{} but the spell only has {} output(s)",
+                i,
+                outs_len
+            );
+        }
+    }
     let apps = apps(spell);
     for (i, n_charm) in spell.tx.outs.iter().enumerate() {
         let has_scroll = n_charm
@@ -1743,5 +1769,60 @@ mod test {
             err.contains("does not match `tx.coins[1].dest`"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn scroll_outputs_listed_rejects_out_of_range_index() {
+        // `tx.outs` has 1 entry (index 0 only), but `tx.scrolls` claims index 1.
+        let mut spell = NormalizedSpell::default();
+        spell.tx.outs = vec![NormalizedCharms::new()];
+        let mut scrolls = BTreeSet::new();
+        scrolls.insert(1u32);
+        spell.tx.scrolls = Some(scrolls);
+        let err = check_scroll_outputs_are_listed(&spell)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("references output #1"), "got: {err}");
+        assert!(err.contains("only has 1 output"), "got: {err}");
+    }
+
+    #[test]
+    fn scroll_outputs_listed_accepts_in_range_non_scroll_index() {
+        // An output index can be declared in `tx.scrolls` even when it carries no
+        // SCROLL charm (the canister signature is the practical gatekeeper on Bitcoin
+        // -- see the reply to greptile on PR #192).
+        let mut spell = NormalizedSpell::default();
+        spell.tx.outs = vec![NormalizedCharms::new(), NormalizedCharms::new()];
+        let mut scrolls = BTreeSet::new();
+        scrolls.insert(1u32);
+        spell.tx.scrolls = Some(scrolls);
+        check_scroll_outputs_are_listed(&spell).unwrap();
+    }
+
+    /// Compact-format Bitcoin tx hex (no spell). Reused from `tx::tests::ser_to_json`
+    /// so the test doesn't drag in a separate fixture.
+    const SAMPLE_BTC_TX_HEX: &str = "0200000000010115ccf0534b7969e5ac0f4699e51bf7805168244057059caa333397fcf8a9acdd0000000000fdffffff027a6faf85150000001600147b458433d0c04323426ef88365bd4cfef141ac7520a107000000000022512087a397fc19d816b6f938dad182a54c778d2d5db8b31f4528a758b989d42f0b78024730440220072d64b2e3bbcd27bd79cb8859c83ca524dad60dc6310569c2a04c997d116381022071d4df703d037a9fe16ccb1a2b8061f10cda86ccbb330a49c5dcc95197436c960121030db9616d96a7b7a8656191b340f77e905ee2885a09a7a1e80b9c8b64ec746fb300000000";
+    const SAMPLE_CARDANO_TX_HEX: &str = "84a400d901028182582011a2338987035057f6c36286cf5aadc02573059b2cde9790017eb4e148f0c67a0001828258390174f84e13070bb755eaa01cb717da8c7450daf379948e979f6de99d26ba89ff199fde572546b9a044eb129ad2edb184bd79cde63ab4b47aec1a01312d008258390184f1c3b1fff5241088acc4ce0aec81f45a71a70e35c94e30a70b7cdfeb0785cdec744029db6b4f344b1123497c9cabfeeb94af20fcfddfe01a33e578fd021a000299e90758201e8eb8575d879922d701c12daa7366cb71b6518a9500e083a966a8e66b56ed23a10081825820ea444825bbd5cc97b6c795437849fe55694b52e2f51485ac76ca2d9f991e83305840d59db4fa0b4bb233504f5e6826261a2e18b2e22cb3df4f631ab77d94d62e8df3200536271f3f3a625bc86919714972964f070f909f145b342f2889f58ccc210ff5a11902a2a1636d736765546f6b656f";
+
+    #[test]
+    fn hosting_chain_follows_first_input_not_any_prev_tx() {
+        use crate::tx::EnchantedTx;
+
+        let btc_tx = Tx::try_from(SAMPLE_BTC_TX_HEX).unwrap();
+        let cardano_tx = Tx::try_from(SAMPLE_CARDANO_TX_HEX).unwrap();
+        let btc_txid = btc_tx.tx_id();
+        let cardano_txid = cardano_tx.tx_id();
+
+        // Spell's first input points at the *Cardano* tx -> hosting chain is Cardano,
+        // even though a Bitcoin tx is also present in `prev_txs` (as it would be for
+        // a Cardano spell beaming charms in from a Bitcoin source).
+        let mut spell = NormalizedSpell::default();
+        spell.tx.ins = Some(vec![UtxoId(cardano_txid, 0)]);
+        let prev_txs = vec![cardano_tx.clone(), btc_tx.clone()];
+        assert!(!hosting_chain_is_bitcoin(&spell, &prev_txs));
+
+        // Mirror image: first input points at the Bitcoin tx -> Bitcoin host.
+        spell.tx.ins = Some(vec![UtxoId(btc_txid, 0)]);
+        assert!(hosting_chain_is_bitcoin(&spell, &prev_txs));
     }
 }

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -133,14 +133,15 @@ pub struct NormalizedTransaction {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coins: Option<Vec<NativeOutput>>,
 
-    /// Indexes of outputs that MUST be sent to a Scrolls-managed address on Bitcoin.
+    /// Indexes of outputs that MUST be sent to a Scrolls-managed `scriptPubKey` on
+    /// Bitcoin.
     ///
-    /// When non-empty on a Bitcoin spell, [`SpellProverInput::scrolls_addresses`] MUST
-    /// carry the signed `output_index -> address` map obtained by calling `addresses()`
-    /// on the `scrolls_bitcoin_v15` canister (passing the Bitcoin network — `"main"` or
-    /// `"testnet4"` — the spell's first input UTXO outpoint, and this set of indexes).
-    /// [`is_correct`] verifies the canister's BIP-340 Schnorr signature and that this
-    /// set equals the keys of the signed address map.
+    /// When non-empty on a Bitcoin spell, [`SpellProverInput::scroll_outputs`] MUST
+    /// carry the signed `output_index -> scriptPubKey` map obtained by calling
+    /// `addresses()` on the `scrolls_bitcoin_v15` canister (passing the spell's first
+    /// input UTXO outpoint and this set of indexes). [`is_correct`] verifies the
+    /// canister's BIP-340 Schnorr signature, that this set equals the keys of the
+    /// signed map, and that each signed `scriptPubKey` equals `tx.coins[i].dest`.
     ///
     /// Every spell-output containing a charm whose app has tag [`charms_data::SCROLL`]
     /// MUST have its index listed here.
@@ -377,14 +378,15 @@ pub fn charms(spell: &NormalizedSpell, n_charms: &NormalizedCharms) -> Charms {
         .collect()
 }
 
-/// Output of the `scrolls_bitcoin_v15` canister's `addresses(...)` endpoint:
-/// a map from spell-output index to its derived P2WPKH address, plus a hex-encoded
-/// BIP-340 Schnorr signature over the CBOR serialization of the map, produced under
-/// the canister's chain key derivation path `[b"sign"]`. The signature is verified
-/// against [`crate::bitcoin_tx::SCROLLS_ADDRS_PUBKEY`].
+/// Output of the `scrolls_bitcoin_v15` canister's `addresses(...)` endpoint: a map
+/// from spell-output index to its derived P2WPKH `scriptPubKey` (hex-encoded raw
+/// script bytes — the same bytes that go into `tx.coins[i].dest`), plus a
+/// hex-encoded BIP-340 Schnorr signature over the CBOR serialization of the map,
+/// produced under the canister's chain key derivation path `[b"sign"]`. The
+/// signature is verified against [`crate::bitcoin_tx::SCROLLS_ADDRS_PUBKEY`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct SignedScrollsAddresses {
-    pub addresses: BTreeMap<u32, String>,
+pub struct SignedScrollOutputs {
+    pub script_pubkeys: BTreeMap<u32, String>,
     pub signature: String,
 }
 
@@ -395,11 +397,12 @@ pub struct SpellProverInput {
     pub spell: NormalizedSpell,
     pub tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
     pub app_input: Option<AppInput>,
-    /// Signed `output_index -> address` map for the spell's Scrolls outputs. MUST be
-    /// `Some` whenever the spell is on Bitcoin and [`NormalizedTransaction::scrolls`]
-    /// is non-empty. Verified inside [`is_correct`].
+    /// Signed `output_index -> scriptPubKey` map for the spell's Scrolls outputs.
+    /// MUST be `Some` whenever the spell is on Bitcoin and
+    /// [`NormalizedTransaction::scrolls`] is non-empty. Verified inside
+    /// [`is_correct`].
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub scrolls_addresses: Option<SignedScrollsAddresses>,
+    pub scroll_outputs: Option<SignedScrollOutputs>,
 }
 
 /// Check if the spell is correct.
@@ -409,7 +412,7 @@ pub fn is_correct(
     app_input: Option<AppInput>,
     spell_vk: &str,
     tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
-    scrolls_addresses: Option<&SignedScrollsAddresses>,
+    scroll_outputs: Option<&SignedScrollOutputs>,
 ) -> anyhow::Result<bool> {
     ensure!(beaming_txs_have_finality_proofs(
         prev_txs,
@@ -435,7 +438,7 @@ pub fn is_correct(
     check_prev_versioned_apps_consistency(&prev_spells)?;
     check_scroll_outputs_are_listed(spell)?;
     if prev_txs.iter().any(|tx| matches!(tx, Tx::Bitcoin(_))) {
-        check_scrolls_addresses(spell, scrolls_addresses)?;
+        check_scroll_outputs(spell, scroll_outputs)?;
     }
 
     let apps = apps(spell);
@@ -876,7 +879,7 @@ fn apps_satisfied(
 
 /// Every output that carries a charm whose app has tag [`SCROLL`] MUST have its index
 /// listed in `spell.tx.scrolls`. The chain-conditional signature check lives in
-/// [`check_scrolls_addresses`]; this structural rule applies regardless of chain (on
+/// [`check_scroll_outputs`]; this structural rule applies regardless of chain (on
 /// Cardano the SCROLL app behaves as a regular non-token app, but the index still has
 /// to be declared so the spell shape stays uniform across chains).
 fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()> {
@@ -901,37 +904,65 @@ fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()
     Ok(())
 }
 
-/// Verify the canister-signed Scrolls address map. Called only when the spell is on
-/// Bitcoin. When `spell.tx.scrolls` is non-empty, the signed map MUST be provided, its
-/// keys MUST equal `spell.tx.scrolls`, and its BIP-340 Schnorr signature MUST verify
-/// under [`SCROLLS_ADDRS_PUBKEY`] over `SHA-256(CBOR(addresses))` (the same digest the
-/// `scrolls_bitcoin_v15` canister signs).
-fn check_scrolls_addresses(
+/// Verify the canister-signed Scrolls `scriptPubKey` map. Called only when the spell
+/// is on Bitcoin. When `spell.tx.scrolls` is non-empty:
+///
+/// * the signed map MUST be provided,
+/// * its keys MUST equal `spell.tx.scrolls`,
+/// * each signed `scriptPubKey` MUST equal `spell.tx.coins[i].dest` (hex-encoded),
+///   pinning the Bitcoin output to the canister-controlled script, and
+/// * its BIP-340 Schnorr signature MUST verify under [`SCROLLS_ADDRS_PUBKEY`] over
+///   `SHA-256(CBOR(script_pubkeys))` (the same digest the `scrolls_bitcoin_v15`
+///   canister signs).
+fn check_scroll_outputs(
     spell: &NormalizedSpell,
-    scrolls_addresses: Option<&SignedScrollsAddresses>,
+    scroll_outputs: Option<&SignedScrollOutputs>,
 ) -> anyhow::Result<()> {
     let Some(scrolls) = spell.tx.scrolls.as_ref().filter(|s| !s.is_empty()) else {
         return Ok(());
     };
-    let Some(scrolls_addresses) = scrolls_addresses else {
+    let Some(scroll_outputs) = scroll_outputs else {
         bail!(
-            "Bitcoin spell declares {} Scrolls output(s) but no signed address map was provided",
+            "Bitcoin spell declares {} Scrolls output(s) but no signed scriptPubKey map was provided",
             scrolls.len()
         );
     };
-    let signed_keys: BTreeSet<u32> = scrolls_addresses.addresses.keys().copied().collect();
+    let signed_keys: BTreeSet<u32> = scroll_outputs.script_pubkeys.keys().copied().collect();
     ensure!(
         scrolls == &signed_keys,
-        "signed Scrolls address map keys ({:?}) do not match `tx.scrolls` ({:?})",
+        "signed Scrolls scriptPubKey map keys ({:?}) do not match `tx.scrolls` ({:?})",
         signed_keys,
         scrolls
     );
-    verify_scrolls_addresses_signature(scrolls_addresses)
+    let coins = spell
+        .tx
+        .coins
+        .as_ref()
+        .ok_or_else(|| anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set"))?;
+    for (&i, signed_spk_hex) in &scroll_outputs.script_pubkeys {
+        let coin = coins.get(i as usize).ok_or_else(|| {
+            anyhow!(
+                "tx.scrolls references output #{} but tx.coins only has {} entries",
+                i,
+                coins.len()
+            )
+        })?;
+        let dest_hex = hex::encode(&coin.dest);
+        ensure!(
+            signed_spk_hex.eq_ignore_ascii_case(&dest_hex),
+            "scroll output #{}: signed scriptPubKey ({}) does not match `tx.coins[{}].dest` ({})",
+            i,
+            signed_spk_hex,
+            i,
+            dest_hex
+        );
+    }
+    verify_scroll_outputs_signature(scroll_outputs)
 }
 
-fn verify_scrolls_addresses_signature(s: &SignedScrollsAddresses) -> anyhow::Result<()> {
-    let message_bytes =
-        util::write(&s.addresses).context("serializing Scrolls addresses for signature check")?;
+fn verify_scroll_outputs_signature(s: &SignedScrollOutputs) -> anyhow::Result<()> {
+    let message_bytes = util::write(&s.script_pubkeys)
+        .context("serializing Scrolls scriptPubKeys for signature check")?;
     let digest: [u8; 32] = Sha256::digest(&message_bytes).into();
     let msg = Message::from_digest(digest);
 
@@ -943,7 +974,7 @@ fn verify_scrolls_addresses_signature(s: &SignedScrollsAddresses) -> anyhow::Res
 
     Secp256k1::verification_only()
         .verify_schnorr(&sig, &msg, &pk)
-        .context("verifying Scrolls address-map Schnorr signature")
+        .context("verifying Scrolls scriptPubKey-map Schnorr signature")
 }
 
 pub fn ensure_no_zero_amounts(norm_spell: &NormalizedSpell) -> anyhow::Result<()> {
@@ -1627,5 +1658,90 @@ mod test {
         let s = serde_json::to_string(&bs0).unwrap();
         let bs1: BeamSource = serde_json::from_str(&s).unwrap();
         assert_eq!(bs1, bs0);
+    }
+
+    /// Build a minimal Bitcoin-shaped spell with `scrolls = {1}`, coin at index 1
+    /// carrying `dest_hex` as a hex-decoded scriptPubKey.
+    fn spell_with_scroll_output_at(dest_hex: &str) -> NormalizedSpell {
+        let mut spell = NormalizedSpell::default();
+        let mut scrolls = BTreeSet::new();
+        scrolls.insert(1u32);
+        spell.tx.scrolls = Some(scrolls);
+        spell.tx.coins = Some(vec![
+            NativeOutput {
+                amount: 0,
+                dest: vec![],
+                content: None,
+            },
+            NativeOutput {
+                amount: 0,
+                dest: hex::decode(dest_hex).unwrap(),
+                content: None,
+            },
+        ]);
+        spell
+    }
+
+    fn signed_scrolls_for(index: u32, spk_hex: &str) -> SignedScrollOutputs {
+        let mut script_pubkeys = BTreeMap::new();
+        script_pubkeys.insert(index, spk_hex.to_string());
+        SignedScrollOutputs {
+            script_pubkeys,
+            // Signature isn't validated here — these tests cover the structural
+            // checks that run *before* `verify_scroll_outputs_signature`.
+            signature: "00".repeat(64),
+        }
+    }
+
+    /// Sample P2WPKH scriptPubKey: `OP_0 <20-byte hash>` (24 hex chars after the
+    /// `0014` prefix). Any 20-byte payload works for these structural checks.
+    const SAMPLE_P2WPKH_SPK: &str = "0014aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const OTHER_P2WPKH_SPK: &str = "0014bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    #[test]
+    fn check_scroll_outputs_skips_when_no_scrolls() {
+        // Empty / absent `tx.scrolls` means there's nothing to check; the
+        // signature need not be present and the function must succeed.
+        let mut spell = NormalizedSpell::default();
+        spell.tx.coins = Some(vec![]);
+        check_scroll_outputs(&spell, None).unwrap();
+        spell.tx.scrolls = Some(BTreeSet::new());
+        check_scroll_outputs(&spell, None).unwrap();
+    }
+
+    #[test]
+    fn check_scroll_outputs_requires_signed_map_when_scrolls_present() {
+        let spell = spell_with_scroll_output_at(SAMPLE_P2WPKH_SPK);
+        let err = check_scroll_outputs(&spell, None).unwrap_err().to_string();
+        assert!(
+            err.contains("no signed scriptPubKey map was provided"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_scroll_outputs_rejects_signed_keys_mismatch() {
+        let spell = spell_with_scroll_output_at(SAMPLE_P2WPKH_SPK);
+        // Signed map declares output #2, but the spell's `tx.scrolls` is {1}.
+        let signed = signed_scrolls_for(2, SAMPLE_P2WPKH_SPK);
+        let err = check_scroll_outputs(&spell, Some(&signed))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("do not match `tx.scrolls`"), "got: {err}");
+    }
+
+    #[test]
+    fn check_scroll_outputs_rejects_spk_mismatch_with_dest() {
+        // Signed scriptPubKey is `OTHER_P2WPKH_SPK`, but the spell's
+        // `coins[1].dest` was filled with `SAMPLE_P2WPKH_SPK`.
+        let spell = spell_with_scroll_output_at(SAMPLE_P2WPKH_SPK);
+        let signed = signed_scrolls_for(1, OTHER_P2WPKH_SPK);
+        let err = check_scroll_outputs(&spell, Some(&signed))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not match `tx.coins[1].dest`"),
+            "got: {err}"
+        );
     }
 }

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -2,7 +2,7 @@ use crate::{
     bitcoin_tx::SCROLLS_ADDRS_PUBKEY,
     tx::{EnchantedTx, Tx, by_txid, extended_normalized_spell},
 };
-use anyhow::{Context, anyhow, bail, ensure};
+use anyhow::{Context, anyhow, ensure};
 use bitcoin::secp256k1::{Message, Secp256k1, XOnlyPublicKey, schnorr::Signature};
 use charms_app_runner::AppRunner;
 use charms_data::{
@@ -136,12 +136,18 @@ pub struct NormalizedTransaction {
     /// Indexes of outputs that MUST be sent to a Scrolls-managed `scriptPubKey` on
     /// Bitcoin.
     ///
-    /// When non-empty on a Bitcoin spell, [`SpellProverInput::scroll_outputs`] MUST
-    /// carry the signed `output_index -> scriptPubKey` map obtained by calling
-    /// `addresses()` on the `scrolls_bitcoin_v15` canister (passing the spell's first
-    /// input UTXO outpoint and this set of indexes). [`is_correct`] verifies the
+    /// Clients prepare a spell with these indexes listed and `coins[i].dest = vec![]`
+    /// for each scroll output. The prover server then calls the
+    /// `scrolls_bitcoin_v15` canister's `addresses()` endpoint to obtain a signed
+    /// `output_index -> scriptPubKey` map, writes each `scriptPubKey` into
+    /// `coins[i].dest`, and threads the signed map through to the zkVM as
+    /// [`SpellProverInput::scroll_outputs`]. [`is_correct`] then verifies the
     /// canister's BIP-340 Schnorr signature, that this set equals the keys of the
     /// signed map, and that each signed `scriptPubKey` equals `tx.coins[i].dest`.
+    ///
+    /// On the client side (before the server hop), `is_correct` returns `Ok(false)`
+    /// for spells with unbound scroll outputs; callers like `charms spell check` and
+    /// the prove-request preflight tolerate that "not yet" signal.
     ///
     /// Every spell-output containing a charm whose app has tag [`charms_data::SCROLL`]
     /// MUST have its index listed here.
@@ -437,9 +443,17 @@ pub fn is_correct(
     check_input_apps_are_referenced(spell, &prev_spells, tx_ins_beamed_source_utxos)?;
     check_prev_versioned_apps_consistency(&prev_spells)?;
     check_scroll_outputs_are_listed(spell)?;
-    if hosting_chain_is_bitcoin(spell, prev_txs) {
-        check_scroll_outputs(spell, scroll_outputs)?;
-    }
+
+    // Scrolls scriptPubKey-map check. May return `Ok(false)` on the client
+    // preflight path (the spell declares Scrolls outputs but the signed map
+    // hasn't been fetched -- the prover server fills it in via
+    // `fill_scroll_outputs`). We don't bail early on `false`: the rest of the
+    // checks still run, and the "not yet" signal is folded into the final
+    // result below. The zkVM spell-checker asserts `Ok(true)` and so refuses to
+    // prove until the binding is in place; host-side callers that run before
+    // the server hop tolerate `Ok(false)`.
+    let scrolls_ok = !hosting_chain_is_bitcoin(spell, prev_txs)
+        || check_scroll_outputs(spell, scroll_outputs)?;
 
     let apps = apps(spell);
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
@@ -485,7 +499,7 @@ pub fn is_correct(
         }
     }
 
-    Ok(true)
+    Ok(scrolls_ok)
 }
 
 /// Gate on which a version change must hand off to the new app's contract: when any spent
@@ -931,27 +945,35 @@ fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()
 }
 
 /// Verify the canister-signed Scrolls `scriptPubKey` map. Called only when the spell
-/// is on Bitcoin. When `spell.tx.scrolls` is non-empty:
+/// is on Bitcoin.
 ///
-/// * the signed map MUST be provided,
-/// * its keys MUST equal `spell.tx.scrolls`,
-/// * each signed `scriptPubKey` MUST equal `spell.tx.coins[i].dest` (hex-encoded),
-///   pinning the Bitcoin output to the canister-controlled script, and
-/// * its BIP-340 Schnorr signature MUST verify under [`SCROLLS_ADDRS_PUBKEY`] over
+/// Returns:
+///
+/// * `Ok(true)` -- nothing to check (no Scrolls outputs declared), or the signed map
+///   is present and every check passes.
+/// * `Ok(false)` -- Scrolls outputs are declared but no signed map was supplied
+///   (the client preflight path, where `coins[i].dest` for those outputs is also
+///   still empty -- the prover server fills both in via `fill_scroll_outputs`).
+/// * `Err(_)` -- the signed map is present but a structural or cryptographic check
+///   failed.
+///
+/// When the signed map is present, these MUST all hold:
+///
+/// * its keys equal `spell.tx.scrolls`,
+/// * each signed `scriptPubKey` equals `spell.tx.coins[i].dest` (hex-encoded),
+///   pinning the Bitcoin output to the canister-controlled script,
+/// * its BIP-340 Schnorr signature verifies under [`SCROLLS_ADDRS_PUBKEY`] over
 ///   `SHA-256(CBOR(script_pubkeys))` (the same digest the `scrolls_bitcoin_v15`
 ///   canister signs).
 fn check_scroll_outputs(
     spell: &NormalizedSpell,
     scroll_outputs: Option<&SignedScrollOutputs>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<bool> {
     let Some(scrolls) = spell.tx.scrolls.as_ref().filter(|s| !s.is_empty()) else {
-        return Ok(());
+        return Ok(true);
     };
     let Some(scroll_outputs) = scroll_outputs else {
-        bail!(
-            "Bitcoin spell declares {} Scrolls output(s) but no signed scriptPubKey map was provided",
-            scrolls.len()
-        );
+        return Ok(false);
     };
     let signed_keys: BTreeSet<u32> = scroll_outputs.script_pubkeys.keys().copied().collect();
     ensure!(
@@ -983,7 +1005,8 @@ fn check_scroll_outputs(
             dest_hex
         );
     }
-    verify_scroll_outputs_signature(scroll_outputs)
+    verify_scroll_outputs_signature(scroll_outputs)?;
+    Ok(true)
 }
 
 fn verify_scroll_outputs_signature(s: &SignedScrollOutputs) -> anyhow::Result<()> {
@@ -1725,24 +1748,23 @@ mod test {
     const OTHER_P2WPKH_SPK: &str = "0014bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     #[test]
-    fn check_scroll_outputs_skips_when_no_scrolls() {
-        // Empty / absent `tx.scrolls` means there's nothing to check; the
-        // signature need not be present and the function must succeed.
+    fn check_scroll_outputs_returns_true_when_no_scrolls() {
+        // Empty / absent `tx.scrolls` means there's nothing to check; the function
+        // returns `Ok(true)` even without a signed map.
         let mut spell = NormalizedSpell::default();
         spell.tx.coins = Some(vec![]);
-        check_scroll_outputs(&spell, None).unwrap();
+        assert!(check_scroll_outputs(&spell, None).unwrap());
         spell.tx.scrolls = Some(BTreeSet::new());
-        check_scroll_outputs(&spell, None).unwrap();
+        assert!(check_scroll_outputs(&spell, None).unwrap());
     }
 
     #[test]
-    fn check_scroll_outputs_requires_signed_map_when_scrolls_present() {
+    fn check_scroll_outputs_returns_false_when_signed_map_absent() {
+        // Client preflight: spell declares Scrolls outputs but the prover server
+        // hasn't filled in the signed `scriptPubKey` map yet. Function returns
+        // `Ok(false)` rather than bailing -- host-side callers tolerate.
         let spell = spell_with_scroll_output_at(SAMPLE_P2WPKH_SPK);
-        let err = check_scroll_outputs(&spell, None).unwrap_err().to_string();
-        assert!(
-            err.contains("no signed scriptPubKey map was provided"),
-            "got: {err}"
-        );
+        assert!(!check_scroll_outputs(&spell, None).unwrap());
     }
 
     #[test]

--- a/charms-spell-checker/src/lib.rs
+++ b/charms-spell-checker/src/lib.rs
@@ -20,7 +20,7 @@ pub fn run(input: SpellProverInput) -> (String, NormalizedSpell) {
         spell,
         tx_ins_beamed_source_utxos,
         app_input,
-        scrolls_addresses,
+        scroll_outputs,
     } = input;
 
     // Check the spell that we're proving is correct.
@@ -31,7 +31,7 @@ pub fn run(input: SpellProverInput) -> (String, NormalizedSpell) {
             app_input,
             &self_spell_vk,
             &tx_ins_beamed_source_utxos,
-            scrolls_addresses.as_ref(),
+            scroll_outputs.as_ref(),
         )
         .unwrap()
     );

--- a/charms-spell-checker/src/lib.rs
+++ b/charms-spell-checker/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run(input: SpellProverInput) -> (String, NormalizedSpell) {
         spell,
         tx_ins_beamed_source_utxos,
         app_input,
+        scrolls_addresses,
     } = input;
 
     // Check the spell that we're proving is correct.
@@ -30,6 +31,7 @@ pub fn run(input: SpellProverInput) -> (String, NormalizedSpell) {
             app_input,
             &self_spell_vk,
             &tx_ins_beamed_source_utxos,
+            scrolls_addresses.as_ref(),
         )
         .unwrap()
     );

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -1,10 +1,15 @@
-// Result of [`addresses`]: the map from output index to derived P2WPKH address,
-// plus a BIP-340 Schnorr signature over the CBOR-serialized map produced by the
-// canister's chain key under derivation path `[b"sign"]`. The signature is
-// hex-encoded.
-type AddressesResult = record {
+// Result of [`addresses`]: the map from output index to its derived P2WPKH
+// `scriptPubKey` (hex-encoded raw script bytes), plus a BIP-340 Schnorr
+// signature over the CBOR-serialized map produced by the canister's chain
+// key under derivation path `[b"sign"]`. The signature is hex-encoded.
+//
+// The `scriptPubKey` is what goes directly into a Bitcoin output's
+// `script_pubkey` field; it is the same byte string that ends up in
+// `spell.tx.coins[i].dest`. Unlike an address, it is network-independent —
+// P2WPKH scripts have identical bytes on `main` and `testnet4`.
+type Addresses = record {
   signature : text;
-  addresses : vec record { nat32; text };
+  script_pubkeys : vec record { nat32; text };
 };
 type Config = record {
   fee_per_input : nat64;
@@ -12,7 +17,7 @@ type Config = record {
   fixed_cost : nat64;
   fee_basis_points : nat64;
 };
-type Result = variant { Ok : AddressesResult; Err : text };
+type Result = variant { Ok : Addresses; Err : text };
 type Result_1 = variant { Ok : nat; Err : text };
 type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
 type Result_3 = variant { Ok : text; Err : text };
@@ -23,24 +28,28 @@ type SignRequest = record {
   tx_to_sign : text;
 };
 service : () -> {
-  // Returns Scroll-controlled P2WPKH addresses for the given network and derivation anchor,
-  // together with a BIP-340 Schnorr signature over the address map produced by the canister's
-  // chain key under derivation path `[b"sign"]`.
-  // 
+  // Returns the Scroll-controlled P2WPKH `scriptPubKey`s (hex-encoded) for the
+  // given derivation anchor, together with a BIP-340 Schnorr signature over the
+  // `(output_index -> scriptPubKey)` map produced by the canister's chain key
+  // under derivation path `[b"sign"]`.
+  //
   // `tx_in_0` is a string of the form `txid_hex:vout` (or block height for coinbase).
   // It identifies the unique "anchor" used for key derivation:
-  // 
+  //
   // * For a normal (non-coinbase) output, this is the outpoint (`{txid}:{vout}`) of the *first
   // input* of the transaction that created the output(s) being addressed.
   // * For an output created by a **coinbase** transaction, use the all-zeros txid (the txid that
   // appears as the first input's `txid` of the coinbase transaction itself) together with the
   // block height (as a decimal integer) in place of the vout. Example:
   // `0000000000000000000000000000000000000000000000000000000000000000:123456`
-  // 
-  // `out_is` is a list of output indexes (within the creating transaction)
-  // for which addresses should be generated. At most 256 indexes are accepted
+  //
+  // `out_is` is a list of output indexes (within the creating transaction) for
+  // which `scriptPubKey`s should be generated. At most 256 indexes are accepted
   // per call.
-  addresses : (text, text, vec nat32) -> (Result);
+  //
+  // No `network` argument is taken because a P2WPKH `scriptPubKey` is just
+  // `OP_0 <20-byte-pubkey-hash>` — the same bytes on every Bitcoin network.
+  addresses : (text, vec nat32) -> (Result);
   config : () -> (Config) query;
   // Current cycle balance of this canister.
   // 

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -425,20 +425,26 @@ fn spell_to_hex(spell: NormalizedSpell) -> Result<String, String> {
     Ok(hex::encode(spell_bytes))
 }
 
-/// Result of [`addresses`]: the map from output index to derived P2WPKH address,
-/// plus a BIP-340 Schnorr signature over the CBOR-serialized map produced by the
-/// canister's chain key under derivation path `[b"sign"]`. The signature is
-/// hex-encoded.
+/// Result of [`addresses`]: the map from output index to its derived P2WPKH
+/// `scriptPubKey` (hex-encoded raw script bytes), plus a BIP-340 Schnorr
+/// signature over the CBOR-serialized map produced by the canister's chain
+/// key under derivation path `[b"sign"]`. The signature is hex-encoded.
+///
+/// The `scriptPubKey` is what goes directly into a Bitcoin output's
+/// `script_pubkey` field; it is the same byte string that ends up in
+/// `spell.tx.coins[i].dest`. Unlike an address, it is network-independent —
+/// P2WPKH scripts have identical bytes on `main` and `testnet4`.
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
-pub struct AddressesResult {
-    pub addresses: BTreeMap<u32, String>,
+pub struct Addresses {
+    pub script_pubkeys: BTreeMap<u32, String>,
     pub signature: String,
 }
 
 #[ic_cdk::update]
-/// Returns Scroll-controlled P2WPKH addresses for the given network and derivation anchor,
-/// together with a BIP-340 Schnorr signature over the address map produced by the canister's
-/// chain key under derivation path `[b"sign"]`.
+/// Returns the Scroll-controlled P2WPKH `scriptPubKey`s (hex-encoded) for the
+/// given derivation anchor, together with a BIP-340 Schnorr signature over the
+/// `(output_index -> scriptPubKey)` map produced by the canister's chain key
+/// under derivation path `[b"sign"]`.
 ///
 /// `tx_in_0` is a string of the form `txid_hex:vout` (or block height for coinbase).
 /// It identifies the unique "anchor" used for key derivation:
@@ -450,24 +456,19 @@ pub struct AddressesResult {
 ///   block height (as a decimal integer) in place of the vout. Example:
 ///   `0000000000000000000000000000000000000000000000000000000000000000:123456`
 ///
-/// `out_is` is a list of output indexes (within the creating transaction)
-/// for which addresses should be generated. At most 256 indexes are accepted
+/// `out_is` is a list of output indexes (within the creating transaction) for
+/// which `scriptPubKey`s should be generated. At most 256 indexes are accepted
 /// per call.
-pub async fn addresses(
-    network: String,
-    tx_in_0: String,
-    out_is: Vec<u32>,
-) -> Result<AddressesResult, String> {
-    addresses_impl(network, tx_in_0, out_is)
+///
+/// No `network` argument is taken because a P2WPKH `scriptPubKey` is just
+/// `OP_0 <20-byte-pubkey-hash>` — the same bytes on every Bitcoin network.
+pub async fn addresses(tx_in_0: String, out_is: Vec<u32>) -> Result<Addresses, String> {
+    addresses_impl(tx_in_0, out_is)
         .await
         .map_err(|e| e.to_string())
 }
 
-async fn addresses_impl(
-    network: String,
-    tx_in_0: String,
-    out_is: Vec<u32>,
-) -> anyhow::Result<AddressesResult> {
+async fn addresses_impl(tx_in_0: String, out_is: Vec<u32>) -> anyhow::Result<Addresses> {
     ensure!(
         out_is.len() <= 256,
         "Input error: too many output indexes requested (max: 256)"
@@ -475,32 +476,31 @@ async fn addresses_impl(
 
     require_secret_prefix()?;
 
-    let network = check_network(&network)?;
     let tx_in_0: UtxoId = tx_in_0
         .parse()
         .map_err(|e| anyhow!("Input error: invalid tx_in_0: {}", e))?;
 
-    let mut addresses = BTreeMap::new();
+    let mut script_pubkeys = BTreeMap::new();
     for out_i in out_is {
         let public_key = derive_public_key_for_output(&tx_in_0, out_i).await?;
-        let address = bitcoin::Address::p2wpkh(&public_key, network).to_string();
-        addresses.insert(out_i, address);
+        let spk = ScriptBuf::new_p2wpkh(&public_key.wpubkey_hash());
+        script_pubkeys.insert(out_i, hex::encode(spk.as_bytes()));
     }
 
-    let signature = sign_addresses(&addresses).await?;
+    let signature = sign_script_pubkeys(&script_pubkeys).await?;
 
-    Ok(AddressesResult {
-        addresses,
+    Ok(Addresses {
+        script_pubkeys,
         signature,
     })
 }
 
-/// Sign the CBOR serialization of `addresses` (after SHA-256 hashing) with the
-/// canister's BIP-340/secp256k1 Schnorr chain key under derivation path
+/// Sign the CBOR serialization of `script_pubkeys` (after SHA-256 hashing) with
+/// the canister's BIP-340/secp256k1 Schnorr chain key under derivation path
 /// `[b"sign"]`. Returns the hex-encoded signature.
-async fn sign_addresses(addresses: &BTreeMap<u32, String>) -> anyhow::Result<String> {
+async fn sign_script_pubkeys(script_pubkeys: &BTreeMap<u32, String>) -> anyhow::Result<String> {
     let message_bytes =
-        util::write(addresses).context("System error: serializing addresses for signing")?;
+        util::write(script_pubkeys).context("System error: serializing script_pubkeys for signing")?;
     let message_hash = bitcoin::hashes::sha256::Hash::hash(&message_bytes)
         .to_byte_array()
         .to_vec();

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -131,25 +131,27 @@ impl Prove for SpellCli {
         if payload {
             // Normalize the prove request so that the emitted payload matches what
             // would actually be sent to the proving API (e.g., adjust coin contents
-            // based on the selected chain, fill in Scrolls outputs from the canister).
+            // based on the selected chain). We do NOT call the Scrolls canister
+            // here: `coins[i].dest` stays empty for Scrolls outputs, and the prover
+            // server fills both `dest` and the signed scriptPubKey map at prove
+            // time. `is_correct` returns `Ok(false)` in that case, which we
+            // tolerate (with a warning).
             adjust_coin_contents(&mut prove_request.spell, chain)?;
-            let scroll_outputs = crate::tx::scrolls_bitcoin::fill_scroll_outputs(
-                &mut prove_request.spell,
-                chain,
-            )
-            .await?;
 
-            ensure!(
-                charms_client::is_correct(
-                    &prove_request.spell,
-                    &prove_request.prev_txs,
-                    app_input,
-                    SPELL_VK,
-                    &prove_request.tx_ins_beamed_source_utxos,
-                    scroll_outputs.as_ref(),
-                )?,
-                "spell verification failed"
-            );
+            let verified = charms_client::is_correct(
+                &prove_request.spell,
+                &prove_request.prev_txs,
+                app_input,
+                SPELL_VK,
+                &prove_request.tx_ins_beamed_source_utxos,
+                None,
+            )?;
+            if !verified {
+                eprintln!(
+                    "warning: spell has Scrolls outputs whose scriptPubKeys are not \
+                     yet bound; binding happens at proving time on the prover server"
+                );
+            }
 
             match format {
                 Output::Json => println!("{}", serde_json::to_string(&prove_request)?),
@@ -259,17 +261,24 @@ impl Check for SpellCli {
             }),
         };
 
-        ensure!(
-            charms_client::is_correct(
-                &norm_spell,
-                &prev_txs,
-                app_input,
-                SPELL_VK,
-                &tx_ins_beamed_source_utxos,
-                None,
-            )?,
-            "spell verification failed"
-        );
+        // No canister call: `charms spell check` is purely client-side. The signed
+        // scriptPubKey map for Bitcoin Scrolls outputs is the prover server's job;
+        // `is_correct` returns `Ok(false)` in that case and we tolerate it (with a
+        // warning) so authors can sanity-check their spell shape locally.
+        let verified = charms_client::is_correct(
+            &norm_spell,
+            &prev_txs,
+            app_input,
+            SPELL_VK,
+            &tx_ins_beamed_source_utxos,
+            None,
+        )?;
+        if !verified {
+            eprintln!(
+                "warning: spell has Scrolls outputs whose scriptPubKeys are not yet \
+                 bound; binding happens at proving time on the prover server"
+            );
+        }
 
         let version_changed_apps = charms_client::collect_version_changed_apps(
             &norm_spell,

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -141,6 +141,7 @@ impl Prove for SpellCli {
                     app_input,
                     SPELL_VK,
                     &prove_request.tx_ins_beamed_source_utxos,
+                    None,
                 )?,
                 "spell verification failed"
             );
@@ -260,6 +261,7 @@ impl Check for SpellCli {
                 app_input,
                 SPELL_VK,
                 &tx_ins_beamed_source_utxos,
+                None,
             )?,
             "spell verification failed"
         );

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -131,8 +131,13 @@ impl Prove for SpellCli {
         if payload {
             // Normalize the prove request so that the emitted payload matches what
             // would actually be sent to the proving API (e.g., adjust coin contents
-            // based on the selected chain).
+            // based on the selected chain, fill in Scrolls outputs from the canister).
             adjust_coin_contents(&mut prove_request.spell, chain)?;
+            let scroll_outputs = crate::tx::scrolls_bitcoin::fill_scroll_outputs(
+                &mut prove_request.spell,
+                chain,
+            )
+            .await?;
 
             ensure!(
                 charms_client::is_correct(
@@ -141,7 +146,7 @@ impl Prove for SpellCli {
                     app_input,
                     SPELL_VK,
                     &prove_request.tx_ins_beamed_source_utxos,
-                    None,
+                    scroll_outputs.as_ref(),
                 )?,
                 "spell verification failed"
             );

--- a/src/spell/prove.rs
+++ b/src/spell/prove.rs
@@ -133,6 +133,7 @@ impl Prove for Prover {
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
             app_input,
+            scrolls_addresses: None,
         };
 
         let mut stdin = SP1Stdin::new();
@@ -197,6 +198,7 @@ impl Prove for MockProver {
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
             app_input,
+            scrolls_addresses: None,
         };
 
         let mut stdin = SP1Stdin::new();

--- a/src/spell/prove.rs
+++ b/src/spell/prove.rs
@@ -18,7 +18,9 @@ use ark_std::{
     rand::{RngCore, SeedableRng},
     test_rng,
 };
-use charms_client::{BeamSource, MOCK_SPELL_VK, NormalizedSpell, Proof, SpellProverInput};
+use charms_client::{
+    BeamSource, MOCK_SPELL_VK, NormalizedSpell, Proof, SignedScrollOutputs, SpellProverInput,
+};
 use charms_data::{App, AppInput, AppSignature, B32, Data, util};
 use charms_lib::SPELL_VK;
 use sha2::{Digest, Sha256};
@@ -76,6 +78,7 @@ pub trait Prove: Send + Sync {
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
+        scroll_outputs: Option<SignedScrollOutputs>,
     ) -> anyhow::Result<(NormalizedSpell, Proof, u64)>;
 }
 
@@ -112,6 +115,7 @@ impl Prove for Prover {
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
+        scroll_outputs: Option<SignedScrollOutputs>,
     ) -> anyhow::Result<(NormalizedSpell, Proof, u64)> {
         ensure!(
             !norm_spell.mock,
@@ -133,7 +137,7 @@ impl Prove for Prover {
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
             app_input,
-            scrolls_addresses: None,
+            scroll_outputs,
         };
 
         let mut stdin = SP1Stdin::new();
@@ -179,6 +183,7 @@ impl Prove for MockProver {
         app_private_inputs: BTreeMap<App, Data>,
         prev_txs: Vec<charms_client::tx::Tx>,
         tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
+        scroll_outputs: Option<SignedScrollOutputs>,
     ) -> anyhow::Result<(NormalizedSpell, Proof, u64)> {
         let norm_spell = make_mock(norm_spell);
 
@@ -198,7 +203,7 @@ impl Prove for MockProver {
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
             app_input,
-            scrolls_addresses: None,
+            scroll_outputs,
         };
 
         let mut stdin = SP1Stdin::new();

--- a/src/spell/prove_spell_tx.rs
+++ b/src/spell/prove_spell_tx.rs
@@ -6,11 +6,11 @@ use super::{
 use crate::utils::retry;
 use crate::{
     cli::{charms_fee_settings, prove_impl},
-    tx::{bitcoin_tx, cardano_tx},
+    tx::{bitcoin_tx, cardano_tx, scrolls_bitcoin},
 };
 use anyhow::bail;
 use charms_client::{
-    NormalizedSpell,
+    NormalizedSpell, SignedScrollOutputs,
     tx::{Chain, Tx, by_txid},
 };
 use charms_data::util;
@@ -83,6 +83,7 @@ impl ProveSpellTxImpl {
         &self,
         prove_request: ProveRequest,
         app_cycles: u64,
+        scroll_outputs: Option<SignedScrollOutputs>,
     ) -> anyhow::Result<Vec<Tx>> {
         let total_app_cycles = app_cycles;
         let ProveRequest {
@@ -111,6 +112,7 @@ impl ProveSpellTxImpl {
             app_private_inputs,
             prev_txs,
             tx_ins_beamed_source_utxos,
+            scroll_outputs,
         )?;
 
         let total_cycles = if !self.mock {
@@ -209,7 +211,13 @@ impl ProveSpellTx for ProveSpellTxImpl {
 
     #[cfg(feature = "prover")]
     async fn prove_spell_tx(&self, mut prove_request: ProveRequest) -> anyhow::Result<Vec<Tx>> {
-        let app_cycles = self.validate_prove_request(&mut prove_request)?;
+        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
+            &mut prove_request.spell,
+            prove_request.chain,
+        )
+        .await?;
+        let app_cycles =
+            self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
         let norm_spell = &prove_request.spell;
 
         if let Some((cache_client, lock_manager)) = self.cache_client.as_ref() {
@@ -247,7 +255,9 @@ impl ProveSpellTx for ProveSpellTxImpl {
                             )
                             .await?;
 
-                        let r: Vec<Tx> = self.do_prove_spell_tx(prove_request, app_cycles).await?;
+                        let r: Vec<Tx> = self
+                            .do_prove_spell_tx(prove_request, app_cycles, scroll_outputs)
+                            .await?;
 
                         let _: () = con
                             .set(
@@ -273,16 +283,24 @@ impl ProveSpellTx for ProveSpellTxImpl {
                 }
             }
         } else {
-            self.do_prove_spell_tx(prove_request, app_cycles).await
+            self.do_prove_spell_tx(prove_request, app_cycles, scroll_outputs)
+                .await
         }
     }
 
     #[cfg(not(feature = "prover"))]
     #[tracing::instrument(level = "info", skip_all)]
     async fn prove_spell_tx(&self, mut prove_request: ProveRequest) -> anyhow::Result<Vec<Tx>> {
-        let app_cycles = self.validate_prove_request(&mut prove_request)?;
+        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
+            &mut prove_request.spell,
+            prove_request.chain,
+        )
+        .await?;
+        let app_cycles =
+            self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
         if self.mock {
-            return Self::do_prove_spell_tx(self, prove_request, app_cycles).await;
+            return Self::do_prove_spell_tx(self, prove_request, app_cycles, scroll_outputs)
+                .await;
         }
 
         let response = retry(0, || async {

--- a/src/spell/prove_spell_tx.rs
+++ b/src/spell/prove_spell_tx.rs
@@ -81,6 +81,26 @@ pub fn committed_data_hash(normalized_spell: &NormalizedSpell) -> anyhow::Result
 use anyhow::Context;
 
 impl ProveSpellTxImpl {
+    /// Fill the Scrolls scriptPubKey map from the canister, validate the
+    /// resulting `ProveRequest`, and produce the proof. Called only on cache
+    /// miss (or when caching is disabled).
+    #[cfg(feature = "prover")]
+    async fn fill_validate_and_prove(
+        &self,
+        mut prove_request: ProveRequest,
+    ) -> anyhow::Result<Vec<Tx>> {
+        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
+            &mut prove_request.spell,
+            prove_request.chain,
+        )
+        .await?;
+        let (app_cycles, verified) =
+            self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
+        ensure!(verified, "spell verification failed");
+        self.do_prove_spell_tx(prove_request, app_cycles, scroll_outputs)
+            .await
+    }
+
     pub(super) async fn do_prove_spell_tx(
         &self,
         prove_request: ProveRequest,
@@ -212,19 +232,15 @@ impl ProveSpellTx for ProveSpellTxImpl {
     }
 
     #[cfg(feature = "prover")]
-    async fn prove_spell_tx(&self, mut prove_request: ProveRequest) -> anyhow::Result<Vec<Tx>> {
-        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
-            &mut prove_request.spell,
-            prove_request.chain,
-        )
-        .await?;
-        let (app_cycles, verified) =
-            self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
-        ensure!(verified, "spell verification failed");
-        let norm_spell = &prove_request.spell;
-
+    async fn prove_spell_tx(&self, prove_request: ProveRequest) -> anyhow::Result<Vec<Tx>> {
+        // Cache key is computed from the request as received -- *before* the
+        // Scrolls scriptPubKey fill-in. Filling is deterministic in
+        // (tx_in_0, out_is), so any later request with the same content hash
+        // would derive the same scriptPubKeys and produce the same proof;
+        // hashing the pre-fill spell lets a cache hit skip both the IC
+        // canister round-trip (`fill_scroll_outputs`) and the proving step.
         if let Some((cache_client, lock_manager)) = self.cache_client.as_ref() {
-            let committed_data_hash = committed_data_hash(norm_spell)?;
+            let committed_data_hash = committed_data_hash(&prove_request.spell)?;
             let request_key = hex::encode(committed_data_hash);
             let lock_key = format!("LOCK_{}", request_key.as_str());
 
@@ -258,9 +274,11 @@ impl ProveSpellTx for ProveSpellTxImpl {
                             )
                             .await?;
 
-                        let r: Vec<Tx> = self
-                            .do_prove_spell_tx(prove_request, app_cycles, scroll_outputs)
-                            .await?;
+                        // Nothing in the cache and we own the lock: do the
+                        // expensive work. The IC canister call happens here so
+                        // it's only paid when neither the pre-lock nor the
+                        // post-lock cache check found a result.
+                        let r: Vec<Tx> = self.fill_validate_and_prove(prove_request).await?;
 
                         let _: () = con
                             .set(
@@ -286,8 +304,7 @@ impl ProveSpellTx for ProveSpellTxImpl {
                 }
             }
         } else {
-            self.do_prove_spell_tx(prove_request, app_cycles, scroll_outputs)
-                .await
+            self.fill_validate_and_prove(prove_request).await
         }
     }
 

--- a/src/spell/prove_spell_tx.rs
+++ b/src/spell/prove_spell_tx.rs
@@ -4,11 +4,13 @@ use super::{
 };
 #[cfg(not(feature = "prover"))]
 use crate::utils::retry;
+#[cfg(feature = "prover")]
+use crate::tx::scrolls_bitcoin;
 use crate::{
     cli::{charms_fee_settings, prove_impl},
-    tx::{bitcoin_tx, cardano_tx, scrolls_bitcoin},
+    tx::{bitcoin_tx, cardano_tx},
 };
-use anyhow::bail;
+use anyhow::{bail, ensure};
 use charms_client::{
     NormalizedSpell, SignedScrollOutputs,
     tx::{Chain, Tx, by_txid},
@@ -216,8 +218,9 @@ impl ProveSpellTx for ProveSpellTxImpl {
             prove_request.chain,
         )
         .await?;
-        let app_cycles =
+        let (app_cycles, verified) =
             self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
+        ensure!(verified, "spell verification failed");
         let norm_spell = &prove_request.spell;
 
         if let Some((cache_client, lock_manager)) = self.cache_client.as_ref() {
@@ -291,16 +294,28 @@ impl ProveSpellTx for ProveSpellTxImpl {
     #[cfg(not(feature = "prover"))]
     #[tracing::instrument(level = "info", skip_all)]
     async fn prove_spell_tx(&self, mut prove_request: ProveRequest) -> anyhow::Result<Vec<Tx>> {
-        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
-            &mut prove_request.spell,
-            prove_request.chain,
-        )
-        .await?;
-        let app_cycles =
-            self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
+        // Client preflight: don't call the canister. `coins[i].dest` for any
+        // Scrolls output is `vec![]`; `is_correct` returns `Ok(false)` and we
+        // tolerate it. The prover server runs `fill_scroll_outputs` and the
+        // strict version of this check before producing the proof.
+        let (app_cycles, verified) = self.validate_prove_request(&mut prove_request, None)?;
+        if !verified {
+            tracing::info!(
+                "spell has Scrolls outputs awaiting binding; the prover server will \
+                 fill `coins[i].dest` and the signed scriptPubKey map"
+            );
+        }
         if self.mock {
-            return Self::do_prove_spell_tx(self, prove_request, app_cycles, scroll_outputs)
-                .await;
+            // Local mock proving runs the spell-checker SP1 binary, which strictly
+            // requires the signed scriptPubKey map. Mock-proving a Bitcoin spell
+            // with Scrolls outputs from the client without canister access is not
+            // supported -- run a local prover server (`charms server`) for that.
+            ensure!(
+                verified,
+                "mock proving locally requires the signed scriptPubKey map; \
+                 run a prover server (`charms server`) for Bitcoin Scrolls spells"
+            );
+            return Self::do_prove_spell_tx(self, prove_request, app_cycles, None).await;
         }
 
         let response = retry(0, || async {

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -221,11 +221,15 @@ pub fn adjust_coin_contents(norm_spell: &mut NormalizedSpell, chain: Chain) -> a
 }
 
 impl ProveSpellTxImpl {
+    /// Validate a `ProveRequest`, returning the app-cycle total and the `is_correct`
+    /// result. `is_correct` may return `Ok(false)` on the client preflight path when
+    /// the spell has unbound Scrolls outputs (the prover server fills those in via
+    /// `fill_scroll_outputs`); the caller decides whether to treat that as fatal.
     pub fn validate_prove_request(
         &self,
         prove_request: &mut super::request::ProveRequest,
         scroll_outputs: Option<&SignedScrollOutputs>,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<(u64, bool)> {
         ensure!(
             prove_request.spell.mock == self.mock,
             "cannot prove a mock=={} spell on a mock=={} prover",
@@ -278,17 +282,14 @@ impl ProveSpellTxImpl {
             }),
         };
 
-        ensure!(
-            charms_client::is_correct(
-                &norm_spell,
-                &prev_txs,
-                app_input.clone(),
-                SPELL_VK,
-                &tx_ins_beamed_source_utxos,
-                scroll_outputs,
-            )?,
-            "spell verification failed"
-        );
+        let verified = charms_client::is_correct(
+            &norm_spell,
+            &prev_txs,
+            app_input.clone(),
+            SPELL_VK,
+            &tx_ins_beamed_source_utxos,
+            scroll_outputs,
+        )?;
 
         // Calculate cycles for fee estimation
         let total_cycles = if let Some(app_input) = &app_input {
@@ -326,9 +327,21 @@ impl ProveSpellTxImpl {
                 };
                 let coin_outs = (norm_spell.tx.coins.as_ref()).expect("coin outputs are expected");
 
-                // Validate that all output addresses are valid for the network
+                // Validate that all output addresses are valid for the network.
+                // Outputs listed in `tx.scrolls` may legitimately have `dest = []`
+                // on the client preflight path -- the prover server fills them in
+                // via `fill_scroll_outputs`, and `check_scroll_outputs` later pins
+                // each `dest` to the canister-signed scriptPubKey.
+                let scroll_indexes: BTreeSet<u32> = norm_spell
+                    .tx
+                    .scrolls
+                    .clone()
+                    .unwrap_or_default();
                 ensure!(
-                    coin_outs.iter().all(|o| {
+                    coin_outs.iter().enumerate().all(|(i, o)| {
+                        if scroll_indexes.contains(&(i as u32)) && o.dest.is_empty() {
+                            return true;
+                        }
                         bitcoin::Address::from_script(
                             &bitcoin::ScriptBuf::from_bytes(o.dest.clone()),
                             network,
@@ -401,12 +414,12 @@ impl ProveSpellTxImpl {
                     total_sats_in > total_sats_required,
                     "spell inputs must have sufficient value to cover outputs and fees"
                 );
-                Ok(total_cycles)
+                Ok((total_cycles, verified))
             }
             Chain::Cardano => {
                 // TODO
                 tracing::warn!("spell validation for cardano is not yet implemented");
-                Ok(total_cycles)
+                Ok((total_cycles, verified))
             }
         }
     }

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -284,6 +284,7 @@ impl ProveSpellTxImpl {
                 app_input.clone(),
                 SPELL_VK,
                 &tx_ins_beamed_source_utxos,
+                None,
             )?,
             "spell verification failed"
         );

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow, bail, ensure};
 use bitcoin::Network;
 use charms_app_runner::AppRunner;
 use charms_client::{
-    BeamSource, NormalizedSpell,
+    BeamSource, NormalizedSpell, SignedScrollOutputs,
     cardano_tx::OutputContent,
     ensure_no_orphan_versioned_apps,
     tx::{Chain, Tx, by_txid},
@@ -224,6 +224,7 @@ impl ProveSpellTxImpl {
     pub fn validate_prove_request(
         &self,
         prove_request: &mut super::request::ProveRequest,
+        scroll_outputs: Option<&SignedScrollOutputs>,
     ) -> anyhow::Result<u64> {
         ensure!(
             prove_request.spell.mock == self.mock,
@@ -284,7 +285,7 @@ impl ProveSpellTxImpl {
                 app_input.clone(),
                 SPELL_VK,
                 &tx_ins_beamed_source_utxos,
-                None,
+                scroll_outputs,
             )?,
             "spell verification failed"
         );

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -3,6 +3,7 @@ use charms_lib::SPELL_VK;
 
 pub mod bitcoin_tx;
 pub mod cardano_tx;
+pub mod scrolls_bitcoin;
 
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn spell(tx: &Tx, mock: bool) -> Option<NormalizedSpell> {

--- a/src/tx/scrolls_bitcoin.rs
+++ b/src/tx/scrolls_bitcoin.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, anyhow, bail};
+use candid::{CandidType, Decode, Encode, Principal};
+use charms_client::{NormalizedSpell, SignedScrollOutputs, tx::Chain};
+use charms_data::UtxoId;
+use ic_agent::Agent;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// `scrolls_bitcoin_v15` canister on the IC mainnet. The canister derives unique
+/// P2WPKH `scriptPubKey`s from `(tx_in_0, out_i)` and returns a Schnorr signature
+/// over the `(output_index -> scriptPubKey)` map under derivation path `[b"sign"]`,
+/// verifiable against `charms_client::bitcoin_tx::SCROLLS_ADDRS_PUBKEY`.
+const SCROLLS_BITCOIN_V15_CANISTER_ID: &str = "rpgc6-oqaaa-aaaak-qy3uq-cai";
+
+/// Mirror of the canister's [`Addresses`](scrolls_bitcoin::Addresses) result —
+/// declared locally so we don't pull the canister crate into the host build.
+#[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
+struct CanisterAddresses {
+    script_pubkeys: BTreeMap<u32, String>,
+    signature: String,
+}
+
+/// If `spell.tx.scrolls` is non-empty and the spell is on Bitcoin, call the
+/// `scrolls_bitcoin_v15` canister to fetch the signed `scriptPubKey` map and
+/// write each `scriptPubKey` into `spell.tx.coins[i].dest` so the Bitcoin
+/// transaction we ultimately build pays the canister-controlled scripts.
+///
+/// Returns `None` if there's no scrolls work to do (no scroll outputs, not
+/// Bitcoin, or spell-without-inputs — which is a malformed case that the
+/// downstream validator will reject anyway).
+pub async fn fill_scroll_outputs(
+    spell: &mut NormalizedSpell,
+    chain: Chain,
+) -> anyhow::Result<Option<SignedScrollOutputs>> {
+    if chain != Chain::Bitcoin {
+        return Ok(None);
+    }
+    let Some(scrolls) = spell.tx.scrolls.as_ref().filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    let Some(tx_in_0) = spell.tx.ins.as_ref().and_then(|ins| ins.first()).cloned() else {
+        return Ok(None);
+    };
+    let out_is: Vec<u32> = scrolls.iter().copied().collect();
+
+    let signed = call_canister_addresses(&tx_in_0, out_is).await?;
+
+    let coins = spell
+        .tx
+        .coins
+        .as_mut()
+        .ok_or_else(|| anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set"))?;
+    let coins_len = coins.len();
+    for (&i, spk_hex) in &signed.script_pubkeys {
+        let coin = coins.get_mut(i as usize).ok_or_else(|| {
+            anyhow!(
+                "tx.scrolls references output #{} but tx.coins only has {} entries",
+                i,
+                coins_len
+            )
+        })?;
+        let spk = hex::decode(spk_hex)
+            .with_context(|| format!("decoding scriptPubKey hex for output #{}", i))?;
+        coin.dest = spk;
+    }
+    Ok(Some(signed))
+}
+
+async fn call_canister_addresses(
+    tx_in_0: &UtxoId,
+    out_is: Vec<u32>,
+) -> anyhow::Result<SignedScrollOutputs> {
+    let agent = Agent::builder()
+        .with_url("https://ic0.app")
+        .build()
+        .context("Failed to create ICP agent")?;
+
+    let canister_id = Principal::from_text(SCROLLS_BITCOIN_V15_CANISTER_ID)
+        .context("Failed to parse scrolls_bitcoin_v15 canister ID")?;
+
+    let args = Encode!(&tx_in_0.to_string(), &out_is)
+        .context("Failed to encode Candid arguments for addresses()")?;
+
+    let response = agent
+        .update(&canister_id, "addresses")
+        .with_arg(args)
+        .call_and_wait()
+        .await
+        .context("Failed to call scrolls_bitcoin_v15.addresses")?;
+
+    let inner = Decode!(&response, Result<CanisterAddresses, String>)
+        .context("Failed to decode addresses() response")?;
+    let canister_result = match inner {
+        Ok(a) => a,
+        Err(e) => bail!("scrolls_bitcoin_v15.addresses returned error: {}", e),
+    };
+
+    Ok(SignedScrollOutputs {
+        script_pubkeys: canister_result.script_pubkeys,
+        signature: canister_result.signature,
+    })
+}


### PR DESCRIPTION
## Summary

- Adds `NormalizedTransaction.scrolls: Option<BTreeSet<u32>>` (skip-if-none): the set of spell output indexes that MUST go to Scrolls-managed Bitcoin addresses. Every output carrying a `SCROLL`-tagged charm must have its index listed (chain-independent structural rule).
- Adds `SignedScrollsAddresses` and `SpellProverInput.scrolls_addresses` so the `output_index -> address` map produced by `scrolls_bitcoin_v15.addresses()` (the BIP-340 Schnorr-signed result) can be passed into the zkVM.
- Extends `is_correct()` with two checks:
  - **Structural** (`check_scroll_outputs_are_listed`): every output containing a `SCROLL`-tagged charm must appear in `tx.scrolls`.
  - **Bitcoin-only** (`check_scrolls_addresses`): when `tx.scrolls` is non-empty, requires the signed address map, verifies its keys equal `tx.scrolls`, and verifies the BIP-340 Schnorr signature against `SCROLLS_ADDRS_PUBKEY` over `SHA-256(CBOR(addresses))` (the same digest the canister signs).
- Callers (`charms-spell-checker`, `cli/spell.rs`, `spell/validate.rs`, `spell/prove.rs`) pass `None` / `scrolls_addresses: None` for now; populating these from a canister call is a follow-up.

## Test plan

- [x] `cargo build --profile=test` (full workspace) passes.
- [x] `cargo test -p charms-client` — all 55 tests pass.
- [x] `cargo test --workspace --exclude charms` — all pass.
- [x] `test_spell_vk` in the top-level `charms` crate fails on this branch **and** on clean `main` (committed SP1 binaries' mtime check). Pre-existing, unrelated.
- [ ] Follow-up: wire the CLI to call `scrolls_bitcoin_v15.addresses()` with (network, first-input outpoint, output indexes) and populate `SpellProverInput.scrolls_addresses`.
- [ ] Follow-up: end-to-end test with a real Bitcoin spell producing a SCROLL output.