### PR TITLE
Unify Groth16 verification; bump V15 to use `[u8; 32]` spell VKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,10 +2427,8 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sha2 0.10.9",
- "sp1-primitives 6.2.0",
- "sp1-verifier 5.2.4",
- "sp1-verifier 6.2.0",
- "sp1-verifier-legacy",
+ "sp1-primitives",
+ "sp1-verifier",
  "strum 0.28.0",
  "test-strategy",
  "thiserror 2.0.18",
@@ -2471,7 +2469,7 @@ dependencies = [
 name = "charms-proof-wrapper"
 version = "15.0.0"
 dependencies = [
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-sdk",
  "sp1-zkvm",
  "tokio",
@@ -3546,7 +3544,6 @@ dependencies = [
  "ff 0.13.1",
  "generic-array 0.14.9",
  "group 0.13.0",
- "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -5788,23 +5785,8 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "serde",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
-dependencies = [
- "num-bigint 0.4.6",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
+ "p3-field",
+ "p3-matrix",
  "serde",
 ]
 
@@ -5816,10 +5798,10 @@ checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version 0.4.1",
  "serde",
@@ -5833,9 +5815,9 @@ checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
 dependencies = [
  "ff 0.13.1",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "serde",
 ]
@@ -5846,10 +5828,10 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -5862,23 +5844,10 @@ checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
-dependencies = [
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "tracing",
 ]
 
 [[package]]
@@ -5887,25 +5856,11 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48948a0516b349e9d1cdb95e7236a6ee010c44e68c5cc78b4b92bf1c4022a0d9"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -5917,7 +5872,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "rand 0.8.6",
  "serde",
 ]
@@ -5931,12 +5886,12 @@ dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
  "p3-interpolation",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -5947,9 +5902,9 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
 ]
 
 [[package]]
@@ -5959,10 +5914,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a087526deb74bf12cc4efc1e50d5c387120624b15ea1de1f3efb440efbcd4d"
 dependencies = [
  "p3-air",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
 ]
 
@@ -5974,28 +5929,13 @@ checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version 0.4.1",
  "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -6005,19 +5945,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.6",
  "serde",
  "tracing",
 ]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -6030,31 +5964,16 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.6",
 ]
 
@@ -6066,27 +5985,13 @@ checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
-dependencies = [
- "gcd",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -6096,21 +6001,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
 dependencies = [
  "gcd",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
  "serde",
 ]
 
@@ -6121,7 +6015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -6135,22 +6029,13 @@ dependencies = [
  "p3-air",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8177,7 +8062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -8199,7 +8084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600f97a93155d2d282a14b959794a80c4995fbb81610c6a8198096b03f4399f8"
 dependencies = [
  "lazy_static",
- "p3-baby-bear 0.3.3-succinct",
+ "p3-baby-bear",
  "serde",
  "slop-algebra",
  "slop-challenger",
@@ -8303,7 +8188,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f77cbedc5e155f6b1ffcf9e2de08a4b847a2b5e4f64a60da2f815f637e0783f7"
 dependencies = [
- "p3-dft 0.3.3-succinct",
+ "p3-dft",
  "serde",
  "slop-algebra",
  "slop-alloc",
@@ -8399,7 +8284,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae933b974a9070a25874b868805e9edf326a170b750564296d6bddfd83676cfe"
 dependencies = [
- "p3-matrix 0.3.3-succinct",
+ "p3-matrix",
 ]
 
 [[package]]
@@ -8408,7 +8293,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3875f2ff3985b9bead2dfa49a801beac3cbe3319d0a87c092403db26236ff5f3"
 dependencies = [
- "p3-maybe-rayon 0.3.3-succinct",
+ "p3-maybe-rayon",
 ]
 
 [[package]]
@@ -8466,7 +8351,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
 dependencies = [
- "p3-poseidon2 0.3.3-succinct",
+ "p3-poseidon2",
 ]
 
 [[package]]
@@ -8525,7 +8410,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
 dependencies = [
- "p3-symmetric 0.3.3-succinct",
+ "p3-symmetric",
 ]
 
 [[package]]
@@ -8563,7 +8448,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8cd0c08e8dd8c16e134da340867c3eb77bcc0d68f0bfd6663f482e695c8035"
 dependencies = [
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "tracing-forest 0.1.6",
  "tracing-subscriber",
 ]
@@ -8657,7 +8542,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -8691,7 +8576,7 @@ dependencies = [
  "sp1-curves",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "strum 0.27.2",
  "subenum",
  "thiserror 1.0.69",
@@ -8717,7 +8602,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner-binary",
  "sp1-jit",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sysinfo",
  "tracing",
  "uuid",
@@ -8773,7 +8658,7 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "static_assertions",
  "struct-reflection",
  "strum 0.27.2",
@@ -8804,7 +8689,7 @@ dependencies = [
  "serde",
  "slop-algebra",
  "snowbridge-amcl",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "typenum",
 ]
 
@@ -8859,7 +8744,7 @@ dependencies = [
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "struct-reflection",
  "strum 0.27.2",
  "thiserror 1.0.69",
@@ -8880,21 +8765,9 @@ dependencies = [
  "memfd",
  "memmap2",
  "serde",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
-dependencies = [
- "bincode",
- "elliptic-curve",
- "serde",
- "sp1-primitives 5.2.4",
 ]
 
 [[package]]
@@ -8905,27 +8778,7 @@ checksum = "d1ce7f8d6098c930fb0c03c60f1c8b0ef61b6625811b210b2c694801ceb62f78"
 dependencies = [
  "bincode",
  "serde",
- "sp1-primitives 6.2.0",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "p3-baby-bear 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "serde",
- "sha2 0.10.9",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -8997,14 +8850,14 @@ dependencies = [
  "sp1-derive",
  "sp1-hypercube",
  "sp1-jit",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-prover-types",
  "sp1-recursion-circuit",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
  "sp1-recursion-machine",
- "sp1-verifier 6.2.0",
+ "sp1-verifier",
  "static_assertions",
  "sysinfo",
  "tempfile",
@@ -9033,7 +8886,7 @@ dependencies = [
  "serde",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "tokio",
  "tonic",
  "tonic-build",
@@ -9073,7 +8926,7 @@ dependencies = [
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-compiler",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
@@ -9095,7 +8948,7 @@ dependencies = [
  "slop-symmetric",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "tracing",
  "vec_map",
@@ -9143,9 +8996,9 @@ dependencies = [
  "slop-algebra",
  "slop-symmetric",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-compiler",
- "sp1-verifier 6.2.0",
+ "sp1-verifier",
  "tempfile",
  "tracing",
 ]
@@ -9166,7 +9019,7 @@ dependencies = [
  "slop-symmetric",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "strum 0.27.2",
  "tracing",
@@ -9209,12 +9062,12 @@ dependencies = [
  "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
  "sp1-recursion-gnark-ffi",
- "sp1-verifier 6.2.0",
+ "sp1-verifier",
  "strum 0.27.2",
  "tempfile",
  "thiserror 1.0.69",
@@ -9223,21 +9076,6 @@ dependencies = [
  "tracing",
  "twirp-rs",
  "zstd",
-]
-
-[[package]]
-name = "sp1-verifier"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
-dependencies = [
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "sha2 0.10.9",
- "substrate-bn-succinct",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9259,34 +9097,7 @@ dependencies = [
  "slop-primitives",
  "slop-symmetric",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
- "sp1-recursion-executor",
- "sp1-recursion-machine",
- "strum 0.27.2",
- "substrate-bn-succinct-rs",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sp1-verifier-legacy"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556d7132484a0b5bb1b2b1d23c5a9b87105fd1727adeb84d383ae8976c81390"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "dirs",
- "hex",
- "lazy_static",
- "serde",
- "sha2 0.10.9",
- "slop-algebra",
- "slop-challenger",
- "slop-primitives",
- "slop-symmetric",
- "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum 0.27.2",
@@ -9310,8 +9121,8 @@ dependencies = [
  "rand 0.8.6",
  "sha2 0.10.9",
  "slop-algebra",
- "sp1-lib 6.2.0",
- "sp1-primitives 6.2.0",
+ "sp1-lib",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -9506,23 +9317,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "substrate-bn-succinct"
-version = "0.6.0-v5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
-dependencies = [
- "bytemuck",
- "byteorder",
- "cfg-if",
- "crunchy",
- "lazy_static",
- "num-bigint 0.4.6",
- "rand 0.8.6",
- "rustc-hex",
- "sp1-lib 5.2.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,6 +2460,7 @@ version = "15.0.0"
 dependencies = [
  "charms-client",
  "getrandom 0.4.2",
+ "hex-literal 1.1.0",
  "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",

--- a/charms-client/Cargo.toml
+++ b/charms-client/Cargo.toml
@@ -33,8 +33,6 @@ serde_with = { version = "3.20.0", features = ["hex", "base64"] }
 sha2 = { workspace = true }
 sp1-primitives = { workspace = true }
 sp1-verifier = { workspace = true, default-features = false }
-sp1-verifier_5 = { package = "sp1-verifier", version = "5.2.4", default-features = false }
-sp1-verifier-v6_0 = { package = "sp1-verifier-legacy", version = "6.0.2" }
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = { version = "2" }
 tracing = { workspace = true }

--- a/charms-client/src/bitcoin_tx.rs
+++ b/charms-client/src/bitcoin_tx.rs
@@ -9,6 +9,7 @@ use bitcoin::{
     script::{Instruction, PushBytes},
 };
 use charms_data::{NativeOutput, TxId, UtxoId, util};
+use hex_literal::hex;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -67,7 +68,7 @@ impl BitcoinTx {
 impl EnchantedTx for BitcoinTx {
     fn extract_and_verify_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         mock: bool,
     ) -> anyhow::Result<NormalizedSpell> {
         let tx = self.inner();
@@ -99,7 +100,7 @@ impl EnchantedTx for BitcoinTx {
 
         let spell_vk = tx::spell_vk(spell.version, spell_vk, spell.mock)?;
 
-        let public_values = tx::to_serialized_pv(spell.version, &(spell_vk, &spell));
+        let public_values = tx::to_serialized_pv(spell.version, spell_vk, &spell);
 
         tx::verify_snark_proof(&proof, &public_values, spell_vk, spell.version, spell.mock)?;
 
@@ -108,7 +109,7 @@ impl EnchantedTx for BitcoinTx {
 
     fn virtual_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         next_spell: &NormalizedSpell,
     ) -> anyhow::Result<NormalizedSpell> {
         match self.extract_and_verify_spell(spell_vk, next_spell.mock) {
@@ -186,7 +187,7 @@ pub const FINALITY_TARGET_BITS: u32 = 0x16507000; // mainnet finality target bit
 /// canister `schnorr_public_key` call). It is used by the client to verify the
 /// Schnorr signature returned by the canister's `addresses(...)` endpoint.
 pub const SCROLLS_ADDRS_PUBKEY: [u8; 32] =
-    hex_literal::hex!("30109b1c3c8dc1812de6267cd864a5f1f794330c6e43c25f971e6d0ae9440e3b");
+    hex!("30109b1c3c8dc1812de6267cd864a5f1f794330c6e43c25f971e6d0ae9440e3b");
 
 fn verify_finality_proof(
     tx: &Transaction,

--- a/charms-client/src/bitcoin_tx.rs
+++ b/charms-client/src/bitcoin_tx.rs
@@ -364,8 +364,8 @@ pub fn parse_spell_and_proof_from_witness(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use super::*;
+    use std::str::FromStr;
 
     fn compute_finality_target(target_bits: u32) -> CompactTarget {
         let compact = CompactTarget::from_consensus(target_bits);
@@ -400,7 +400,9 @@ mod tests {
 
     #[test]
     fn scrolls_addrs_pubkey_is_the_one_derived_for_icp_threshold_schnorr() {
-        use ic_pub_key::{derive_schnorr_key, CanisterId, SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgs};
+        use ic_pub_key::{
+            CanisterId, SchnorrAlgorithm, SchnorrKeyId, SchnorrPublicKeyArgs, derive_schnorr_key,
+        };
 
         // Textual canister ID for rpgc6-oqaaa-aaaak-qy3uq-cai.
         let canister_id = CanisterId::from_str("rpgc6-oqaaa-aaaak-qy3uq-cai").unwrap();
@@ -419,7 +421,11 @@ mod tests {
         // The crate (and the live management canister) returns the Schnorr public key
         // in SEC1 compressed form (33 bytes, 0x02/0x03 prefix + 32-byte x coord).
         // SCROLLS_ADDRS_PUBKEY stores the 32-byte x-only form used for BIP-340 verification.
-        assert_eq!(result.public_key.len(), 33, "expected 33-byte SEC1 compressed key");
+        assert_eq!(
+            result.public_key.len(),
+            33,
+            "expected 33-byte SEC1 compressed key"
+        );
         let derived_x_only: [u8; 32] = result.public_key[1..].try_into().unwrap();
 
         assert_eq!(SCROLLS_ADDRS_PUBKEY, derived_x_only);

--- a/charms-client/src/cardano_tx.rs
+++ b/charms-client/src/cardano_tx.rs
@@ -79,7 +79,7 @@ impl CardanoTx {
 impl EnchantedTx for CardanoTx {
     fn extract_and_verify_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         mock: bool,
     ) -> anyhow::Result<NormalizedSpell> {
         let tx = self.inner();
@@ -134,7 +134,7 @@ impl EnchantedTx for CardanoTx {
 
         let spell_vk = tx::spell_vk(spell.version, spell_vk, spell.mock)?;
 
-        let public_values = tx::to_serialized_pv(spell.version, &(spell_vk, &spell));
+        let public_values = tx::to_serialized_pv(spell.version, spell_vk, &spell);
 
         tx::verify_snark_proof(&proof, &public_values, spell_vk, spell.version, spell.mock)?;
 
@@ -143,7 +143,7 @@ impl EnchantedTx for CardanoTx {
 
     fn virtual_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         next_spell: &NormalizedSpell,
     ) -> anyhow::Result<NormalizedSpell> {
         match self.extract_and_verify_spell(spell_vk, next_spell.mock) {

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -10,6 +10,7 @@ use charms_data::{
     VersionedApp, check, is_simple_transfer, util,
 };
 use const_format::formatcp;
+use hex_literal::hex;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, IfIsHumanReadable, serde_as};
 use sha2::{Digest, Sha256};
@@ -22,36 +23,51 @@ pub mod request;
 pub mod sorted_app_map;
 pub mod tx;
 
-pub const MOCK_SPELL_VK: &str = "7c38e8639a2eac0074cee920982b92376513e8940f4a7ca6859f17a728af5b0e";
+pub const MOCK_SPELL_VK: [u8; 32] =
+    hex!("7c38e8639a2eac0074cee920982b92376513e8940f4a7ca6859f17a728af5b0e");
 
 /// Verification key for version `0` of the protocol implemented by `charms-spell-checker` binary.
-pub const V0_SPELL_VK: &str = "0x00e9398ac819e6dd281f81db3ada3fe5159c3cc40222b5ddb0e7584ed2327c5d";
+pub const V0_SPELL_VK: [u8; 32] =
+    hex!("00e9398ac819e6dd281f81db3ada3fe5159c3cc40222b5ddb0e7584ed2327c5d");
 /// Verification key for version `1` of the protocol implemented by `charms-spell-checker` binary.
-pub const V1_SPELL_VK: &str = "0x009f38f590ebca4c08c1e97b4064f39e4cd336eea4069669c5f5170a38a1ff97";
+pub const V1_SPELL_VK: [u8; 32] =
+    hex!("009f38f590ebca4c08c1e97b4064f39e4cd336eea4069669c5f5170a38a1ff97");
 /// Verification key for version `2` of the protocol implemented by `charms-spell-checker` binary.
-pub const V2_SPELL_VK: &str = "0x00bd312b6026dbe4a2c16da1e8118d4fea31587a4b572b63155252d2daf69280";
+pub const V2_SPELL_VK: [u8; 32] =
+    hex!("00bd312b6026dbe4a2c16da1e8118d4fea31587a4b572b63155252d2daf69280");
 /// Verification key for version `3` of the protocol implemented by `charms-spell-checker` binary.
-pub const V3_SPELL_VK: &str = "0x0034872b5af38c95fe82fada696b09a448f7ab0928273b7ac8c58ba29db774b9";
+pub const V3_SPELL_VK: [u8; 32] =
+    hex!("0034872b5af38c95fe82fada696b09a448f7ab0928273b7ac8c58ba29db774b9");
 /// Verification key for version `4` of the protocol implemented by `charms-spell-checker` binary.
-pub const V4_SPELL_VK: &str = "0x00c707a155bf8dc18dc41db2994c214e93e906a3e97b4581db4345b3edd837c5";
+pub const V4_SPELL_VK: [u8; 32] =
+    hex!("00c707a155bf8dc18dc41db2994c214e93e906a3e97b4581db4345b3edd837c5");
 /// Verification key for version `5` of the protocol implemented by `charms-spell-checker` binary.
-pub const V5_SPELL_VK: &str = "0x00e98665c417bd2e6e81c449af63b26ed5ad5c400ef55811b592450bf62c67cd";
+pub const V5_SPELL_VK: [u8; 32] =
+    hex!("00e98665c417bd2e6e81c449af63b26ed5ad5c400ef55811b592450bf62c67cd");
 /// Verification key for version `6` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V6_SPELL_VK: &str = "0x005a1df17094445572e4dd474b3e5dd9093936cba62ca3a62bb2ce63d9db8cba";
+pub const V6_SPELL_VK: [u8; 32] =
+    hex!("005a1df17094445572e4dd474b3e5dd9093936cba62ca3a62bb2ce63d9db8cba");
 /// Verification key for version `7` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V7_SPELL_VK: &str = "0x0041d9843ec25ba04797a0ce29af364389f7eda9f7126ef39390c357432ad9aa";
+pub const V7_SPELL_VK: [u8; 32] =
+    hex!("0041d9843ec25ba04797a0ce29af364389f7eda9f7126ef39390c357432ad9aa");
 /// Verification key for version `8` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V8_SPELL_VK: &str = "0x00e440d40e331c16bc4c78d2dbc6bb35876e6ea944e943de359a075e07385abc";
+pub const V8_SPELL_VK: [u8; 32] =
+    hex!("00e440d40e331c16bc4c78d2dbc6bb35876e6ea944e943de359a075e07385abc");
 /// Verification key for version `9` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V9_SPELL_VK: &str = "0x00713f077ec2bd68157512835dc678053565a889935ecd5789ce2fa097c93ee9";
+pub const V9_SPELL_VK: [u8; 32] =
+    hex!("00713f077ec2bd68157512835dc678053565a889935ecd5789ce2fa097c93ee9");
 /// Verification key for version `10` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V10_SPELL_VK: &str = "0x00ccf030317cae019a4cd3c8557b2c5b522050e7e562e3adf287cd5ad596511f";
+pub const V10_SPELL_VK: [u8; 32] =
+    hex!("00ccf030317cae019a4cd3c8557b2c5b522050e7e562e3adf287cd5ad596511f");
 /// Verification key for version `11` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V11_SPELL_VK: &str = "0x00d41d49f54303acee4e7d064a31e0c9bd2e1bbdb60f39170a1461c71015c308";
+pub const V11_SPELL_VK: [u8; 32] =
+    hex!("00d41d49f54303acee4e7d064a31e0c9bd2e1bbdb60f39170a1461c71015c308");
 /// Verification key for version `12` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V12_SPELL_VK: &str = "0x00cd44537c67da0dc50b88e794deed43c4507a862070ed83c99941789811a6a0";
+pub const V12_SPELL_VK: [u8; 32] =
+    hex!("00cd44537c67da0dc50b88e794deed43c4507a862070ed83c99941789811a6a0");
 /// Verification key for version `13` of the protocol implemented by `charms-proof-wrapper` binary.
-pub const V13_SPELL_VK: &str = "0x004ef5bd2f6ed0c33b022dcc263bde479421d81a82ca0cb1a99d9ff361f89895";
+pub const V13_SPELL_VK: [u8; 32] =
+    hex!("004ef5bd2f6ed0c33b022dcc263bde479421d81a82ca0cb1a99d9ff361f89895");
 
 /// Version `0` of the protocol.
 pub const V0: u32 = 0;
@@ -220,7 +236,7 @@ pub fn utxo_id_hash_with_nonce(utxo_id: &UtxoId, nonce: Option<u64>) -> B32 {
 #[tracing::instrument(level = "debug", skip(prev_txs, spell_vk))]
 pub fn prev_spells(
     prev_txs: &[Tx],
-    spell_vk: &str,
+    spell_vk: &[u8; 32],
     norm_spell: &NormalizedSpell,
 ) -> anyhow::Result<BTreeMap<TxId, (NormalizedSpell, usize)>> {
     prev_txs
@@ -398,7 +414,7 @@ pub struct SignedScrollOutputs {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpellProverInput {
-    pub self_spell_vk: String,
+    pub self_spell_vk: [u8; 32],
     pub prev_txs: Vec<Tx>,
     pub spell: NormalizedSpell,
     pub tx_ins_beamed_source_utxos: BTreeMap<usize, BeamSource>,
@@ -416,7 +432,7 @@ pub fn is_correct(
     spell: &NormalizedSpell,
     prev_txs: &Vec<Tx>,
     app_input: Option<AppInput>,
-    spell_vk: &str,
+    spell_vk: &[u8; 32],
     tx_ins_beamed_source_utxos: &BTreeMap<usize, BeamSource>,
     scroll_outputs: Option<&SignedScrollOutputs>,
 ) -> anyhow::Result<bool> {

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -68,6 +68,9 @@ pub const V12_SPELL_VK: [u8; 32] =
 /// Verification key for version `13` of the protocol implemented by `charms-proof-wrapper` binary.
 pub const V13_SPELL_VK: [u8; 32] =
     hex!("004ef5bd2f6ed0c33b022dcc263bde479421d81a82ca0cb1a99d9ff361f89895");
+/// Verification key for version `14` of the protocol implemented by `charms-proof-wrapper` binary.
+pub const V14_SPELL_VK: [u8; 32] =
+    hex!("001a2396afb7e376736d9cf82d33c0dec55cb66866bf7f141fdaa92ab70a0506");
 
 /// Version `0` of the protocol.
 pub const V0: u32 = 0;
@@ -99,9 +102,11 @@ pub const V12: u32 = 12;
 pub const V13: u32 = 13;
 /// Version `14` of the protocol.
 pub const V14: u32 = 14;
+/// Version `15` of the protocol.
+pub const V15: u32 = 15;
 
 /// Current version of the protocol.
-pub const CURRENT_VERSION: u32 = V14;
+pub const CURRENT_VERSION: u32 = V15;
 
 pub const CHARMS_PROVE_API_URL: &'static str =
     formatcp!("https://v{CURRENT_VERSION}.charms.dev/spells/prove");

--- a/charms-client/src/lib.rs
+++ b/charms-client/src/lib.rs
@@ -468,8 +468,8 @@ pub fn is_correct(
     // result below. The zkVM spell-checker asserts `Ok(true)` and so refuses to
     // prove until the binding is in place; host-side callers that run before
     // the server hop tolerate `Ok(false)`.
-    let scrolls_ok = !hosting_chain_is_bitcoin(spell, prev_txs)
-        || check_scroll_outputs(spell, scroll_outputs)?;
+    let scrolls_ok =
+        !hosting_chain_is_bitcoin(spell, prev_txs) || check_scroll_outputs(spell, scroll_outputs)?;
 
     let apps = apps(spell);
     let charms_tx = to_tx(spell, &prev_spells, tx_ins_beamed_source_utxos, &prev_txs);
@@ -642,15 +642,13 @@ pub fn check_input_apps_are_referenced(
         let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
             Some(beam_source) => {
                 let beam_source_utxo_id = &beam_source.0;
-                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(
-                    || {
-                        anyhow!(
-                            "missing prev spell for beam source utxo {} (input #{})",
-                            beam_source_utxo_id,
-                            i
-                        )
-                    },
-                )?;
+                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(|| {
+                    anyhow!(
+                        "missing prev spell for beam source utxo {} (input #{})",
+                        beam_source_utxo_id,
+                        i
+                    )
+                })?;
                 (prev_spell, beam_source_utxo_id)
             }
             None => {
@@ -732,16 +730,15 @@ pub fn check_prev_versioned_apps_consistency(
 /// beam source's spell (since that is where the spent charm's metadata lives).
 ///
 /// Scope notes:
-/// - Reference inputs (`spell.tx.refs`) are **not** consulted here: refs are read-only and
-///   don't "spend" a charm, so the version-bump rules don't apply. Cross-tx version
-///   consistency for ref-source spells is still enforced by
-///   [`check_prev_versioned_apps_consistency`], which sees every prev spell.
-/// - This function tolerates the case where a spent charm's `vk` is not referenced by the
-///   spending spell (no successor `(version, wasm_hash)` to constrain). In the full
-///   `is_correct` flow that situation is independently rejected earlier by
-///   [`check_input_apps_are_referenced`], because allowing it would let an app's contract
-///   be bypassed entirely. Keeping the local tolerance here makes this function a pure
-///   per-input rule that can be reasoned about in isolation.
+/// - Reference inputs (`spell.tx.refs`) are **not** consulted here: refs are read-only and don't
+///   "spend" a charm, so the version-bump rules don't apply. Cross-tx version consistency for
+///   ref-source spells is still enforced by [`check_prev_versioned_apps_consistency`], which sees
+///   every prev spell.
+/// - This function tolerates the case where a spent charm's `vk` is not referenced by the spending
+///   spell (no successor `(version, wasm_hash)` to constrain). In the full `is_correct` flow that
+///   situation is independently rejected earlier by [`check_input_apps_are_referenced`], because
+///   allowing it would let an app's contract be bypassed entirely. Keeping the local tolerance here
+///   makes this function a pure per-input rule that can be reasoned about in isolation.
 pub fn check_app_version_continuity(
     spell: &NormalizedSpell,
     prev_spells: &BTreeMap<TxId, (NormalizedSpell, usize)>,
@@ -751,23 +748,20 @@ pub fn check_app_version_continuity(
         unreachable!("called after well_formed");
     };
 
-    let referenced_vks: BTreeSet<&B32> =
-        spell.app_public_inputs.keys().map(|a| &a.vk).collect();
+    let referenced_vks: BTreeSet<&B32> = spell.app_public_inputs.keys().map(|a| &a.vk).collect();
 
     for (i, input_utxo_id) in tx_ins.iter().enumerate() {
         // Resolve which prev spell + utxo carries the spent charms (handling beaming).
         let (source_spell, source_utxo_id) = match tx_ins_beamed_source_utxos.get(&i) {
             Some(beam_source) => {
                 let beam_source_utxo_id = &beam_source.0;
-                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(
-                    || {
-                        anyhow!(
-                            "missing prev spell for beam source utxo {} (input #{})",
-                            beam_source_utxo_id,
-                            i
-                        )
-                    },
-                )?;
+                let (prev_spell, _) = prev_spells.get(&beam_source_utxo_id.0).ok_or_else(|| {
+                    anyhow!(
+                        "missing prev spell for beam source utxo {} (input #{})",
+                        beam_source_utxo_id,
+                        i
+                    )
+                })?;
                 (prev_spell, beam_source_utxo_id)
             }
             None => {
@@ -965,22 +959,20 @@ fn check_scroll_outputs_are_listed(spell: &NormalizedSpell) -> anyhow::Result<()
 ///
 /// Returns:
 ///
-/// * `Ok(true)` -- nothing to check (no Scrolls outputs declared), or the signed map
-///   is present and every check passes.
-/// * `Ok(false)` -- Scrolls outputs are declared but no signed map was supplied
-///   (the client preflight path, where `coins[i].dest` for those outputs is also
-///   still empty -- the prover server fills both in via `fill_scroll_outputs`).
-/// * `Err(_)` -- the signed map is present but a structural or cryptographic check
-///   failed.
+/// * `Ok(true)` -- nothing to check (no Scrolls outputs declared), or the signed map is present and
+///   every check passes.
+/// * `Ok(false)` -- Scrolls outputs are declared but no signed map was supplied (the client
+///   preflight path, where `coins[i].dest` for those outputs is also still empty -- the prover
+///   server fills both in via `fill_scroll_outputs`).
+/// * `Err(_)` -- the signed map is present but a structural or cryptographic check failed.
 ///
 /// When the signed map is present, these MUST all hold:
 ///
 /// * its keys equal `spell.tx.scrolls`,
-/// * each signed `scriptPubKey` equals `spell.tx.coins[i].dest` (hex-encoded),
-///   pinning the Bitcoin output to the canister-controlled script,
+/// * each signed `scriptPubKey` equals `spell.tx.coins[i].dest` (hex-encoded), pinning the Bitcoin
+///   output to the canister-controlled script,
 /// * its BIP-340 Schnorr signature verifies under [`SCROLLS_ADDRS_PUBKEY`] over
-///   `SHA-256(CBOR(script_pubkeys))` (the same digest the `scrolls_bitcoin_v15`
-///   canister signs).
+///   `SHA-256(CBOR(script_pubkeys))` (the same digest the `scrolls_bitcoin_v15` canister signs).
 fn check_scroll_outputs(
     spell: &NormalizedSpell,
     scroll_outputs: Option<&SignedScrollOutputs>,
@@ -998,11 +990,10 @@ fn check_scroll_outputs(
         signed_keys,
         scrolls
     );
-    let coins = spell
-        .tx
-        .coins
-        .as_ref()
-        .ok_or_else(|| anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set"))?;
+    let coins =
+        spell.tx.coins.as_ref().ok_or_else(|| {
+            anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set")
+        })?;
     for (&i, signed_spk_hex) in &scroll_outputs.script_pubkeys {
         let coin = coins.get(i as usize).ok_or_else(|| {
             anyhow!(
@@ -1335,10 +1326,9 @@ mod test {
         prev_ver: Option<VersionedApp>,
         cur_ver: Option<VersionedApp>,
     ) -> (NormalizedSpell, BTreeMap<TxId, (NormalizedSpell, usize)>) {
-        let prev_tx_id = TxId::from_str(
-            "1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .unwrap();
+        let prev_tx_id =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
         let prev_utxo = UtxoId(prev_tx_id, 0);
 
         let mut prev_spell = NormalizedSpell::default();
@@ -1349,12 +1339,18 @@ mod test {
             c.insert(0, Data::empty());
             c
         }];
-        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
-            amount: 0,
-            dest: vec![],
-            content: None,
-        });
-        prev_spell.app_public_inputs.insert(app.clone(), Data::empty());
+        prev_spell
+            .tx
+            .coins
+            .get_or_insert_with(Vec::new)
+            .push(NativeOutput {
+                amount: 0,
+                dest: vec![],
+                content: None,
+            });
+        prev_spell
+            .app_public_inputs
+            .insert(app.clone(), Data::empty());
         if let Some(v) = prev_ver {
             prev_spell.versioned_apps.insert(app.vk.clone(), v);
         }
@@ -1478,10 +1474,7 @@ mod test {
         let err = authorize_version_changes(&spell, &changed, None)
             .unwrap_err()
             .to_string();
-        assert!(
-            err.contains("no app binaries provided"),
-            "got: {err}"
-        );
+        assert!(err.contains("no app binaries provided"), "got: {err}");
         assert!(
             err.contains("A version change requires running the new app binary"),
             "got: {err}"
@@ -1553,21 +1546,24 @@ mod test {
     #[test]
     fn input_apps_referenced_no_input_charms_ok() {
         // Input UTXO has no charms attached -> nothing to require.
-        let prev_tx_id = TxId::from_str(
-            "1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .unwrap();
+        let prev_tx_id =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
         let prev_utxo = UtxoId(prev_tx_id, 0);
 
         let mut prev_spell = NormalizedSpell::default();
         prev_spell.tx.ins = Some(vec![]);
         prev_spell.tx.refs = Some(vec![]);
         prev_spell.tx.outs = vec![NormalizedCharms::new()]; // empty charms
-        prev_spell.tx.coins.get_or_insert_with(Vec::new).push(NativeOutput {
-            amount: 0,
-            dest: vec![],
-            content: None,
-        });
+        prev_spell
+            .tx
+            .coins
+            .get_or_insert_with(Vec::new)
+            .push(NativeOutput {
+                amount: 0,
+                dest: vec![],
+                content: None,
+            });
 
         let mut spell = NormalizedSpell::default();
         spell.tx.ins = Some(vec![prev_utxo]);
@@ -1589,14 +1585,12 @@ mod test {
     #[test]
     fn prev_versioned_apps_consistent_same_hash_ok() {
         let app = an_app();
-        let tx1 = TxId::from_str(
-            "1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .unwrap();
-        let tx2 = TxId::from_str(
-            "2222222222222222222222222222222222222222222222222222222222222222",
-        )
-        .unwrap();
+        let tx1 =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let tx2 =
+            TxId::from_str("2222222222222222222222222222222222222222222222222222222222222222")
+                .unwrap();
         let mut prev_spells = BTreeMap::new();
         prev_spells.insert(
             tx1,
@@ -1612,14 +1606,12 @@ mod test {
     #[test]
     fn prev_versioned_apps_different_hash_same_version_rejected() {
         let app = an_app();
-        let tx1 = TxId::from_str(
-            "1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .unwrap();
-        let tx2 = TxId::from_str(
-            "2222222222222222222222222222222222222222222222222222222222222222",
-        )
-        .unwrap();
+        let tx1 =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let tx2 =
+            TxId::from_str("2222222222222222222222222222222222222222222222222222222222222222")
+                .unwrap();
         let mut prev_spells = BTreeMap::new();
         prev_spells.insert(
             tx1,
@@ -1639,14 +1631,12 @@ mod test {
     fn prev_versioned_apps_different_versions_ok() {
         // Same vk, different versions, different hashes — fine, they're different versions.
         let app = an_app();
-        let tx1 = TxId::from_str(
-            "1111111111111111111111111111111111111111111111111111111111111111",
-        )
-        .unwrap();
-        let tx2 = TxId::from_str(
-            "2222222222222222222222222222222222222222222222222222222222222222",
-        )
-        .unwrap();
+        let tx1 =
+            TxId::from_str("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap();
+        let tx2 =
+            TxId::from_str("2222222222222222222222222222222222222222222222222222222222222222")
+                .unwrap();
         let mut prev_spells = BTreeMap::new();
         prev_spells.insert(
             tx1,
@@ -1665,9 +1655,7 @@ mod test {
         // This must be rejected by `is_correct` (and so by the zkVM proof), not just by
         // the host-side validator.
         let app = an_app();
-        let other_vk = b32(
-            "9999999999999999999999999999999999999999999999999999999999999999",
-        );
+        let other_vk = b32("9999999999999999999999999999999999999999999999999999999999999999");
         let mut spell = NormalizedSpell::default();
         spell.tx.ins = Some(vec![]);
         spell.tx.outs = vec![];

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -108,11 +108,7 @@ pub fn extended_normalized_spell(
     tx.virtual_spell(spell_vk, next_spell)
 }
 
-pub fn spell_vk<'a>(
-    spell_version: u32,
-    spell_vk: &'a [u8; 32],
-    mock: bool,
-) -> anyhow::Result<&'a [u8; 32]> {
+pub fn spell_vk(spell_version: u32, spell_vk: &[u8; 32], mock: bool) -> anyhow::Result<&[u8; 32]> {
     if mock {
         return Ok(&MOCK_SPELL_VK);
     }

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -139,7 +139,12 @@ pub fn spell_vk(spell_version: u32, spell_vk: &[u8; 32], mock: bool) -> anyhow::
 /// (CBOR public values, prover-input JSON, CLI output, etc.) where a string form
 /// is expected.
 pub fn vk_hex(vk: &[u8; 32]) -> String {
-    format!("0x{}", hex::encode(vk))
+    let mut hex_buf = [0u8; 64];
+    hex::encode_to_slice(vk, &mut hex_buf).expect("encoding 32-byte vk into 64-byte buffer");
+    let mut out = String::with_capacity(66);
+    out.push_str("0x");
+    out.push_str(std::str::from_utf8(&hex_buf).expect("hex output is valid ASCII"));
+    out
 }
 
 pub fn groth16_vk(spell_version: u32, mock: bool) -> anyhow::Result<&'static [u8]> {

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -2,15 +2,16 @@ use crate::{
     CURRENT_VERSION, MOCK_SPELL_VK, NormalizedSpell, V0, V0_SPELL_VK, V1, V1_SPELL_VK, V2,
     V2_SPELL_VK, V3, V3_SPELL_VK, V4, V4_SPELL_VK, V5, V5_SPELL_VK, V6, V6_SPELL_VK, V7,
     V7_SPELL_VK, V8, V8_SPELL_VK, V9, V9_SPELL_VK, V10, V10_SPELL_VK, V11, V11_SPELL_VK, V12,
-    V12_SPELL_VK, V13, V13_SPELL_VK, ark, bitcoin_tx::BitcoinTx, cardano_tx::CardanoTx,
+    V12_SPELL_VK, V13, V13_SPELL_VK, V14, ark, bitcoin_tx::BitcoinTx, cardano_tx::CardanoTx,
 };
 use anyhow::{anyhow, bail};
 use charms_data::{NativeOutput, TxId, UtxoId, util};
 use enum_dispatch::enum_dispatch;
+use hex_literal::hex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sp1_primitives::io::SP1PublicValues;
-use sp1_verifier::{Groth16Verifier, decode_sp1_vkey_hash, hash_public_inputs};
+use sp1_verifier::{Groth16Verifier, hash_public_inputs};
 use std::collections::BTreeMap;
 use strum::{AsRefStr, EnumDiscriminants, EnumString};
 use thiserror::Error;
@@ -29,12 +30,12 @@ pub struct UnsupportedSpellVersion(pub u32);
 pub trait EnchantedTx {
     fn extract_and_verify_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         mock: bool,
     ) -> anyhow::Result<NormalizedSpell>;
     fn virtual_spell(
         &self,
-        spell_vk: &str,
+        spell_vk: &[u8; 32],
         next_spell: &NormalizedSpell,
     ) -> anyhow::Result<NormalizedSpell>;
     fn tx_outs_len(&self) -> usize;
@@ -90,7 +91,7 @@ impl Tx {
 /// Incorrect spells are rejected.
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn committed_normalized_spell(
-    spell_vk: &str,
+    spell_vk: &[u8; 32],
     tx: &Tx,
     mock: bool,
 ) -> anyhow::Result<NormalizedSpell> {
@@ -100,35 +101,47 @@ pub fn committed_normalized_spell(
 /// Extract and verify [`NormalizedSpell`] from a transaction. Return an empty spell if the
 /// transaction does not have one. Extend with native coin output amounts if necessary.
 pub fn extended_normalized_spell(
-    spell_vk: &str,
+    spell_vk: &[u8; 32],
     next_spell: &NormalizedSpell,
     tx: &Tx,
 ) -> anyhow::Result<NormalizedSpell> {
     tx.virtual_spell(spell_vk, next_spell)
 }
 
-pub fn spell_vk(spell_version: u32, spell_vk: &str, mock: bool) -> anyhow::Result<&str> {
+pub fn spell_vk<'a>(
+    spell_version: u32,
+    spell_vk: &'a [u8; 32],
+    mock: bool,
+) -> anyhow::Result<&'a [u8; 32]> {
     if mock {
-        return Ok(MOCK_SPELL_VK);
+        return Ok(&MOCK_SPELL_VK);
     }
     match spell_version {
         CURRENT_VERSION => Ok(spell_vk),
-        V13 => Ok(V13_SPELL_VK),
-        V12 => Ok(V12_SPELL_VK),
-        V11 => Ok(V11_SPELL_VK),
-        V10 => Ok(V10_SPELL_VK),
-        V9 => Ok(V9_SPELL_VK),
-        V8 => Ok(V8_SPELL_VK),
-        V7 => Ok(V7_SPELL_VK),
-        V6 => Ok(V6_SPELL_VK),
-        V5 => Ok(V5_SPELL_VK),
-        V4 => Ok(V4_SPELL_VK),
-        V3 => Ok(V3_SPELL_VK),
-        V2 => Ok(V2_SPELL_VK),
-        V1 => Ok(V1_SPELL_VK),
-        V0 => Ok(V0_SPELL_VK),
+        V13 => Ok(&V13_SPELL_VK),
+        V12 => Ok(&V12_SPELL_VK),
+        V11 => Ok(&V11_SPELL_VK),
+        V10 => Ok(&V10_SPELL_VK),
+        V9 => Ok(&V9_SPELL_VK),
+        V8 => Ok(&V8_SPELL_VK),
+        V7 => Ok(&V7_SPELL_VK),
+        V6 => Ok(&V6_SPELL_VK),
+        V5 => Ok(&V5_SPELL_VK),
+        V4 => Ok(&V4_SPELL_VK),
+        V3 => Ok(&V3_SPELL_VK),
+        V2 => Ok(&V2_SPELL_VK),
+        V1 => Ok(&V1_SPELL_VK),
+        V0 => Ok(&V0_SPELL_VK),
         _ => Err(UnsupportedSpellVersion(spell_version).into()),
     }
+}
+
+/// Render a 32-byte verification key as a `"0x"`-prefixed hex string, matching the
+/// format produced by SP1's `vk.bytes32()`. Use this at serialization boundaries
+/// (CBOR public values, prover-input JSON, CLI output, etc.) where a string form
+/// is expected.
+pub fn vk_hex(vk: &[u8; 32]) -> String {
+    format!("0x{}", hex::encode(vk))
 }
 
 pub fn groth16_vk(spell_version: u32, mock: bool) -> anyhow::Result<&'static [u8]> {
@@ -174,18 +187,26 @@ pub const V13_GROTH16_VK_BYTES: &'static [u8] = V12_GROTH16_VK_BYTES;
 pub const V14_GROTH16_VK_BYTES: &'static [u8] = include_bytes!("../vk/v14/groth16_vk.bin");
 pub const CURRENT_GROTH16_VK_BYTES: &'static [u8] = V14_GROTH16_VK_BYTES;
 
-pub fn to_serialized_pv<T: Serialize>(spell_version: u32, t: &T) -> Vec<u8> {
+pub fn to_serialized_pv(
+    spell_version: u32,
+    spell_vk: &[u8; 32],
+    spell: &NormalizedSpell,
+) -> Vec<u8> {
     match spell_version {
         V0 => {
-            // we used to commit to the tuple `(spell_vk, n_spell)`, which was serialized internally
-            // by SP1
+            // V0 committed `(spell_vk, n_spell)` as a `(String, NormalizedSpell)` tuple
+            // serialized internally by SP1.
             let mut pv = SP1PublicValues::new();
-            pv.write(t);
+            pv.write(&(vk_hex(spell_vk), spell));
             pv.to_vec()
         }
+        v if v <= V14 => {
+            // V1..=V14 committed `(spell_vk, n_spell)` as CBOR of `(String, NormalizedSpell)`.
+            util::write(&(vk_hex(spell_vk), spell)).unwrap()
+        }
         _ => {
-            // we commit to CBOR-encoded tuple `(spell_vk, n_spell)`
-            util::write(t).unwrap()
+            // V15+ commits `(spell_vk, n_spell)` as CBOR of `([u8; 32], NormalizedSpell)`.
+            util::write(&(spell_vk, spell)).unwrap()
         }
     }
 }
@@ -193,18 +214,28 @@ pub fn to_serialized_pv<T: Serialize>(spell_version: u32, t: &T) -> Vec<u8> {
 pub fn verify_snark_proof(
     proof: &[u8],
     public_inputs: &[u8],
-    vk_hash: &str,
+    sp1_vkey_hash: &[u8; 32],
     spell_version: u32,
     mock: bool,
 ) -> anyhow::Result<()> {
     let groth16_vk = groth16_vk(spell_version, mock)?;
     match mock {
         false => match spell_version {
-            v if v <= V11 => verify_gnark_v5(proof, public_inputs, vk_hash, groth16_vk),
-            v if v <= V13 => {
-                verify_gnark_v6(proof, public_inputs, vk_hash, groth16_vk, SP1_V6_0_VK_ROOT)
-            }
-            _ => verify_gnark_v6(proof, public_inputs, vk_hash, groth16_vk, SP1_V6_2_VK_ROOT),
+            v if v <= V11 => verify_gnark_v5(proof, public_inputs, sp1_vkey_hash, groth16_vk),
+            v if v <= V13 => verify_gnark_v6(
+                proof,
+                public_inputs,
+                sp1_vkey_hash,
+                groth16_vk,
+                SP1_V6_0_VK_ROOT,
+            ),
+            _ => verify_gnark_v6(
+                proof,
+                public_inputs,
+                sp1_vkey_hash,
+                groth16_vk,
+                SP1_V6_2_VK_ROOT,
+            ),
         },
         true => ark::verify_groth16_proof(proof, public_inputs, groth16_vk),
     }
@@ -214,16 +245,16 @@ const VK_HASH_PREFIX_LENGTH: usize = 4;
 
 /// `VK_ROOT_BYTES` from `sp1-verifier-legacy` 6.0.2 — covers spell versions V12 and V13.
 const SP1_V6_0_VK_ROOT: [u8; 32] =
-    hex_literal::hex!("008cd56e10c2fe24795cff1e1d1f40d3a324528d315674da45d26afb376e8670");
+    hex!("008cd56e10c2fe24795cff1e1d1f40d3a324528d315674da45d26afb376e8670");
 
 /// `VK_ROOT_BYTES` from `sp1-verifier` 6.2.0 — covers the current spell version (V14).
 const SP1_V6_2_VK_ROOT: [u8; 32] =
-    hex_literal::hex!("002f850ee998974d6cc00e50cd0814b098c05bfade466d28573240d057f25352");
+    hex!("002f850ee998974d6cc00e50cd0814b098c05bfade466d28573240d057f25352");
 
 fn verify_gnark_v5(
     proof: &[u8],
     public_inputs: &[u8],
-    vk_hash: &str,
+    sp1_vkey_hash: &[u8; 32],
     groth16_vk: &[u8],
 ) -> anyhow::Result<()> {
     if proof.len() < VK_HASH_PREFIX_LENGTH {
@@ -235,11 +266,9 @@ fn verify_gnark_v5(
     if groth16_vk_hash != proof[..VK_HASH_PREFIX_LENGTH] {
         bail!("could not verify spell proof: groth16 vkey hash mismatch");
     }
-    let sp1_vkey_hash = decode_sp1_vkey_hash(vk_hash)
-        .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))?;
     Groth16Verifier::verify_gnark_proof(
         &proof[VK_HASH_PREFIX_LENGTH..],
-        &[sp1_vkey_hash, hash_public_inputs(public_inputs)],
+        &[*sp1_vkey_hash, hash_public_inputs(public_inputs)],
         groth16_vk,
     )
     .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))
@@ -248,7 +277,7 @@ fn verify_gnark_v5(
 fn verify_gnark_v6(
     proof: &[u8],
     public_inputs: &[u8],
-    vk_hash: &str,
+    sp1_vkey_hash: &[u8; 32],
     groth16_vk: &[u8],
     expected_vk_root: [u8; 32],
 ) -> anyhow::Result<()> {
@@ -261,8 +290,6 @@ fn verify_gnark_v6(
     if groth16_vk_hash != proof[..VK_HASH_PREFIX_LENGTH] {
         bail!("could not verify spell proof: groth16 vkey hash mismatch");
     }
-    let sp1_vkey_hash = decode_sp1_vkey_hash(vk_hash)
-        .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))?;
 
     let exit_code: [u8; 32] = proof[VK_HASH_PREFIX_LENGTH..VK_HASH_PREFIX_LENGTH + 32]
         .try_into()
@@ -284,7 +311,7 @@ fn verify_gnark_v6(
     Groth16Verifier::verify_gnark_proof(
         &proof[VK_HASH_PREFIX_LENGTH + 96..],
         &[
-            sp1_vkey_hash,
+            *sp1_vkey_hash,
             hash_public_inputs(public_inputs),
             exit_code,
             vk_root,
@@ -314,7 +341,7 @@ mod tests {
 
     #[test]
     fn spell_vk_unsupported_version_typed_error() {
-        let err = spell_vk(u32::MAX, "vk", false).unwrap_err();
+        let err = spell_vk(u32::MAX, &[0u8; 32], false).unwrap_err();
         assert_eq!(
             err.downcast_ref::<UnsupportedSpellVersion>(),
             Some(&UnsupportedSpellVersion(u32::MAX))

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -2,7 +2,8 @@ use crate::{
     CURRENT_VERSION, MOCK_SPELL_VK, NormalizedSpell, V0, V0_SPELL_VK, V1, V1_SPELL_VK, V2,
     V2_SPELL_VK, V3, V3_SPELL_VK, V4, V4_SPELL_VK, V5, V5_SPELL_VK, V6, V6_SPELL_VK, V7,
     V7_SPELL_VK, V8, V8_SPELL_VK, V9, V9_SPELL_VK, V10, V10_SPELL_VK, V11, V11_SPELL_VK, V12,
-    V12_SPELL_VK, V13, V13_SPELL_VK, V14, ark, bitcoin_tx::BitcoinTx, cardano_tx::CardanoTx,
+    V12_SPELL_VK, V13, V13_SPELL_VK, V14, V14_SPELL_VK, ark, bitcoin_tx::BitcoinTx,
+    cardano_tx::CardanoTx,
 };
 use anyhow::{anyhow, bail};
 use charms_data::{NativeOutput, TxId, UtxoId, util};
@@ -114,6 +115,7 @@ pub fn spell_vk(spell_version: u32, spell_vk: &[u8; 32], mock: bool) -> anyhow::
     }
     match spell_version {
         CURRENT_VERSION => Ok(spell_vk),
+        V14 => Ok(&V14_SPELL_VK),
         V13 => Ok(&V13_SPELL_VK),
         V12 => Ok(&V12_SPELL_VK),
         V11 => Ok(&V11_SPELL_VK),
@@ -146,6 +148,7 @@ pub fn groth16_vk(spell_version: u32, mock: bool) -> anyhow::Result<&'static [u8
     }
     match spell_version {
         CURRENT_VERSION => Ok(CURRENT_GROTH16_VK_BYTES),
+        V14 => Ok(V14_GROTH16_VK_BYTES),
         V13 => Ok(V13_GROTH16_VK_BYTES),
         V12 => Ok(V12_GROTH16_VK_BYTES),
         V11 => Ok(V11_GROTH16_VK_BYTES),
@@ -181,7 +184,8 @@ pub const V11_GROTH16_VK_BYTES: &'static [u8] = V4_GROTH16_VK_BYTES;
 pub const V12_GROTH16_VK_BYTES: &'static [u8] = include_bytes!("../vk/v12/groth16_vk.bin");
 pub const V13_GROTH16_VK_BYTES: &'static [u8] = V12_GROTH16_VK_BYTES;
 pub const V14_GROTH16_VK_BYTES: &'static [u8] = include_bytes!("../vk/v14/groth16_vk.bin");
-pub const CURRENT_GROTH16_VK_BYTES: &'static [u8] = V14_GROTH16_VK_BYTES;
+pub const V15_GROTH16_VK_BYTES: &'static [u8] = V14_GROTH16_VK_BYTES;
+pub const CURRENT_GROTH16_VK_BYTES: &'static [u8] = V15_GROTH16_VK_BYTES;
 
 pub fn to_serialized_pv(
     spell_version: u32,
@@ -243,7 +247,7 @@ const VK_HASH_PREFIX_LENGTH: usize = 4;
 const SP1_V6_0_VK_ROOT: [u8; 32] =
     hex!("008cd56e10c2fe24795cff1e1d1f40d3a324528d315674da45d26afb376e8670");
 
-/// `VK_ROOT_BYTES` from `sp1-verifier` 6.2.0 — covers the current spell version (V14).
+/// `VK_ROOT_BYTES` from `sp1-verifier` 6.2.0 — covers spell versions V14 and V15.
 const SP1_V6_2_VK_ROOT: [u8; 32] =
     hex!("002f850ee998974d6cc00e50cd0814b098c05bfade466d28573240d057f25352");
 

--- a/charms-client/src/tx.rs
+++ b/charms-client/src/tx.rs
@@ -8,8 +8,9 @@ use anyhow::{anyhow, bail};
 use charms_data::{NativeOutput, TxId, UtxoId, util};
 use enum_dispatch::enum_dispatch;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sp1_primitives::io::SP1PublicValues;
-use sp1_verifier::Groth16Verifier;
+use sp1_verifier::{Groth16Verifier, decode_sp1_vkey_hash, hash_public_inputs};
 use std::collections::BTreeMap;
 use strum::{AsRefStr, EnumDiscriminants, EnumString};
 use thiserror::Error;
@@ -199,22 +200,99 @@ pub fn verify_snark_proof(
     let groth16_vk = groth16_vk(spell_version, mock)?;
     match mock {
         false => match spell_version {
-            v if v <= V11 => {
-                sp1_verifier_5::Groth16Verifier::verify(proof, public_inputs, vk_hash, groth16_vk)
-                    .map_err(|e| anyhow!("could not verify spell proof: {}", e))
+            v if v <= V11 => verify_gnark_v5(proof, public_inputs, vk_hash, groth16_vk),
+            v if v <= V13 => {
+                verify_gnark_v6(proof, public_inputs, vk_hash, groth16_vk, SP1_V6_0_VK_ROOT)
             }
-            v if v <= V13 => sp1_verifier_v6_0::Groth16Verifier::verify(
-                proof,
-                public_inputs,
-                vk_hash,
-                groth16_vk,
-            )
-            .map_err(|e| anyhow!("could not verify spell proof: {}", e)),
-            _ => Groth16Verifier::verify(proof, public_inputs, vk_hash, groth16_vk)
-                .map_err(|e| anyhow!("could not verify spell proof: {}", e)),
+            _ => verify_gnark_v6(proof, public_inputs, vk_hash, groth16_vk, SP1_V6_2_VK_ROOT),
         },
         true => ark::verify_groth16_proof(proof, public_inputs, groth16_vk),
     }
+}
+
+const VK_HASH_PREFIX_LENGTH: usize = 4;
+
+/// `VK_ROOT_BYTES` from `sp1-verifier-legacy` 6.0.2 — covers spell versions V12 and V13.
+const SP1_V6_0_VK_ROOT: [u8; 32] =
+    hex_literal::hex!("008cd56e10c2fe24795cff1e1d1f40d3a324528d315674da45d26afb376e8670");
+
+/// `VK_ROOT_BYTES` from `sp1-verifier` 6.2.0 — covers the current spell version (V14).
+const SP1_V6_2_VK_ROOT: [u8; 32] =
+    hex_literal::hex!("002f850ee998974d6cc00e50cd0814b098c05bfade466d28573240d057f25352");
+
+fn verify_gnark_v5(
+    proof: &[u8],
+    public_inputs: &[u8],
+    vk_hash: &str,
+    groth16_vk: &[u8],
+) -> anyhow::Result<()> {
+    if proof.len() < VK_HASH_PREFIX_LENGTH {
+        bail!("could not verify spell proof: invalid proof");
+    }
+    let groth16_vk_hash: [u8; 4] = Sha256::digest(groth16_vk)[..VK_HASH_PREFIX_LENGTH]
+        .try_into()
+        .map_err(|_| anyhow!("could not verify spell proof: invalid groth16 vk"))?;
+    if groth16_vk_hash != proof[..VK_HASH_PREFIX_LENGTH] {
+        bail!("could not verify spell proof: groth16 vkey hash mismatch");
+    }
+    let sp1_vkey_hash = decode_sp1_vkey_hash(vk_hash)
+        .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))?;
+    Groth16Verifier::verify_gnark_proof(
+        &proof[VK_HASH_PREFIX_LENGTH..],
+        &[sp1_vkey_hash, hash_public_inputs(public_inputs)],
+        groth16_vk,
+    )
+    .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))
+}
+
+fn verify_gnark_v6(
+    proof: &[u8],
+    public_inputs: &[u8],
+    vk_hash: &str,
+    groth16_vk: &[u8],
+    expected_vk_root: [u8; 32],
+) -> anyhow::Result<()> {
+    if proof.len() < VK_HASH_PREFIX_LENGTH + 32 * 3 {
+        bail!("could not verify spell proof: invalid proof");
+    }
+    let groth16_vk_hash: [u8; 4] = Sha256::digest(groth16_vk)[..VK_HASH_PREFIX_LENGTH]
+        .try_into()
+        .map_err(|_| anyhow!("could not verify spell proof: invalid groth16 vk"))?;
+    if groth16_vk_hash != proof[..VK_HASH_PREFIX_LENGTH] {
+        bail!("could not verify spell proof: groth16 vkey hash mismatch");
+    }
+    let sp1_vkey_hash = decode_sp1_vkey_hash(vk_hash)
+        .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))?;
+
+    let exit_code: [u8; 32] = proof[VK_HASH_PREFIX_LENGTH..VK_HASH_PREFIX_LENGTH + 32]
+        .try_into()
+        .unwrap();
+    let vk_root: [u8; 32] = proof[VK_HASH_PREFIX_LENGTH + 32..VK_HASH_PREFIX_LENGTH + 64]
+        .try_into()
+        .unwrap();
+    let proof_nonce: [u8; 32] = proof[VK_HASH_PREFIX_LENGTH + 64..VK_HASH_PREFIX_LENGTH + 96]
+        .try_into()
+        .unwrap();
+
+    if vk_root != expected_vk_root {
+        bail!("could not verify spell proof: vkey root mismatch");
+    }
+    if exit_code != [0u8; 32] {
+        bail!("could not verify spell proof: exit code mismatch");
+    }
+
+    Groth16Verifier::verify_gnark_proof(
+        &proof[VK_HASH_PREFIX_LENGTH + 96..],
+        &[
+            sp1_vkey_hash,
+            hash_public_inputs(public_inputs),
+            exit_code,
+            vk_root,
+            proof_nonce,
+        ],
+        groth16_vk,
+    )
+    .map_err(|e| anyhow!("could not verify spell proof: {:?}", e))
 }
 
 pub fn by_txid(prev_txs: &[Tx]) -> BTreeMap<TxId, Tx> {
@@ -228,6 +306,11 @@ pub fn by_txid(prev_txs: &[Tx]) -> BTreeMap<TxId, Tx> {
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn current_sp1_vk_root_matches_hardcoded_constant() {
+        assert_eq!(SP1_V6_2_VK_ROOT, *sp1_verifier::VK_ROOT_BYTES);
+    }
 
     #[test]
     fn spell_vk_unsupported_version_typed_error() {

--- a/charms-lib/Cargo.toml
+++ b/charms-lib/Cargo.toml
@@ -19,6 +19,7 @@ wasm = ["wasm-bindgen", "serde-wasm-bindgen", "getrandom"]
 [dependencies]
 charms-client = { path = "../charms-client", version = "15.0.0" }
 getrandom = { version = "0.4.2", optional = true, features = ["wasm_js"] }
+hex-literal = { version = "1.1.0" }
 serde-wasm-bindgen = { version = "0.6.5", optional = true }
 wasm-bindgen = { version = "0.2.121", optional = true }
 

--- a/charms-lib/src/lib.rs
+++ b/charms-lib/src/lib.rs
@@ -3,12 +3,14 @@ pub use charms_client::{
     CHARMS_PROVE_API_URL, CURRENT_VERSION, NormalizedCharms, NormalizedSpell,
     NormalizedTransaction, bitcoin_tx, cardano_tx, request, tx,
 };
+use hex_literal::hex;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 /// Verification key for the current `charms-spell-checker` binary
 /// (and the current protocol version).
-pub const SPELL_VK: &str = "0x001a2396afb7e376736d9cf82d33c0dec55cb66866bf7f141fdaa92ab70a0506";
+pub const SPELL_VK: [u8; 32] =
+    hex!("001a2396afb7e376736d9cf82d33c0dec55cb66866bf7f141fdaa92ab70a0506");
 
 #[cfg(feature = "wasm")]
 #[wasm_bindgen(js_name = "extractAndVerifySpell")]
@@ -20,7 +22,7 @@ pub fn extract_and_verify_spell_js(tx: JsValue, mock: bool) -> Result<JsValue, J
 }
 
 pub fn extract_and_verify_spell(tx: &Tx, mock: bool) -> Result<NormalizedSpell, String> {
-    let norm_spell = charms_client::tx::committed_normalized_spell(SPELL_VK, tx, mock)
+    let norm_spell = charms_client::tx::committed_normalized_spell(&SPELL_VK, tx, mock)
         .map_err(|e| e.to_string())?;
     Ok(norm_spell)
 }

--- a/charms-sdk/src/lib.rs
+++ b/charms-sdk/src/lib.rs
@@ -18,8 +18,8 @@ macro_rules! main {
 ///
 /// Expands to:
 /// - `pub const VERSION: u32 = $version;` for use in the app's Rust code, and
-/// - a `#[unsafe(no_mangle)] extern "C" fn __app_version() -> u32` export so the version
-///   is readable from the compiled Wasm binary.
+/// - a `#[unsafe(no_mangle)] extern "C" fn __app_version() -> u32` export so the version is
+///   readable from the compiled Wasm binary.
 ///
 /// Use exactly once at the top of an app's `lib.rs`/`main.rs`. Spell prove and check will
 /// verify that this value matches the `version` declared in `NormalizedSpell::versioned_apps`.

--- a/charms-spell-checker/Cargo.lock
+++ b/charms-spell-checker/Cargo.lock
@@ -742,10 +742,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "sp1-primitives 6.2.0",
- "sp1-verifier 5.2.4",
- "sp1-verifier 6.2.0",
- "sp1-verifier-legacy",
+ "sp1-primitives",
+ "sp1-verifier",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tracing",
@@ -1886,7 +1884,7 @@ dependencies = [
  "once_cell",
  "sha2 0.10.9",
  "signature",
- "sp1-lib 6.2.0",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -2269,23 +2267,8 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "serde",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
-dependencies = [
- "num-bigint 0.4.6",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
+ "p3-field",
+ "p3-matrix",
  "serde",
 ]
 
@@ -2297,10 +2280,10 @@ checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version",
  "serde",
@@ -2314,9 +2297,9 @@ checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
 dependencies = [
  "ff 0.13.1",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "serde",
 ]
@@ -2327,10 +2310,10 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -2343,23 +2326,10 @@ checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
-dependencies = [
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "tracing",
 ]
 
 [[package]]
@@ -2368,25 +2338,11 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48948a0516b349e9d1cdb95e7236a6ee010c44e68c5cc78b4b92bf1c4022a0d9"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -2398,7 +2354,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "rand 0.8.6",
  "serde",
 ]
@@ -2412,12 +2368,12 @@ dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
  "p3-interpolation",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -2428,9 +2384,9 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
 ]
 
 [[package]]
@@ -2441,28 +2397,13 @@ checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version",
  "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -2472,19 +2413,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.6",
  "serde",
  "tracing",
 ]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -2497,31 +2432,16 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.6",
 ]
 
@@ -2533,27 +2453,13 @@ checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
-dependencies = [
- "gcd",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -2563,21 +2469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
 dependencies = [
  "gcd",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
  "serde",
 ]
 
@@ -2588,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -2602,22 +2497,13 @@ dependencies = [
  "p3-air",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3380,7 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2987d60942c83511c5819afdd9ca83a9723fed072c43d5e1144393beebbce49c"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -3402,7 +3288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600f97a93155d2d282a14b959794a80c4995fbb81610c6a8198096b03f4399f8"
 dependencies = [
  "lazy_static",
- "p3-baby-bear 0.3.3-succinct",
+ "p3-baby-bear",
  "serde",
  "slop-algebra",
  "slop-challenger",
@@ -3506,7 +3392,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f77cbedc5e155f6b1ffcf9e2de08a4b847a2b5e4f64a60da2f815f637e0783f7"
 dependencies = [
- "p3-dft 0.3.3-succinct",
+ "p3-dft",
  "serde",
  "slop-algebra",
  "slop-alloc",
@@ -3593,7 +3479,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae933b974a9070a25874b868805e9edf326a170b750564296d6bddfd83676cfe"
 dependencies = [
- "p3-matrix 0.3.3-succinct",
+ "p3-matrix",
 ]
 
 [[package]]
@@ -3602,7 +3488,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3875f2ff3985b9bead2dfa49a801beac3cbe3319d0a87c092403db26236ff5f3"
 dependencies = [
- "p3-maybe-rayon 0.3.3-succinct",
+ "p3-maybe-rayon",
 ]
 
 [[package]]
@@ -3660,7 +3546,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3386c5935d822f8621a19f305dffdcae3d9a1956a7b657a7f8893438abf22526"
 dependencies = [
- "p3-poseidon2 0.3.3-succinct",
+ "p3-poseidon2",
 ]
 
 [[package]]
@@ -3719,7 +3605,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "580a4f683c60b000b7ac8ca3fcd200a2a70f4caf2e43268f9089323534d15ecc"
 dependencies = [
- "p3-symmetric 0.3.3-succinct",
+ "p3-symmetric",
 ]
 
 [[package]]
@@ -3757,7 +3643,7 @@ version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8cd0c08e8dd8c16e134da340867c3eb77bcc0d68f0bfd6663f482e695c8035"
 dependencies = [
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "tracing-forest",
  "tracing-subscriber",
 ]
@@ -3852,25 +3738,13 @@ dependencies = [
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "struct-reflection",
  "strum 0.27.2",
  "thiserror 1.0.69",
  "thousands",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
-dependencies = [
- "bincode",
- "elliptic-curve",
- "serde",
- "sp1-primitives 5.2.4",
 ]
 
 [[package]]
@@ -3882,27 +3756,7 @@ dependencies = [
  "bincode",
  "elliptic-curve",
  "serde",
- "sp1-primitives 6.2.0",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "p3-baby-bear 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "serde",
- "sha2 0.10.9",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -3969,26 +3823,11 @@ dependencies = [
  "slop-symmetric",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "strum 0.27.2",
  "tracing",
  "zkhash",
-]
-
-[[package]]
-name = "sp1-verifier"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
-dependencies = [
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "sha2 0.10.9",
- "substrate-bn-succinct",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4010,34 +3849,7 @@ dependencies = [
  "slop-primitives",
  "slop-symmetric",
  "sp1-hypercube",
- "sp1-primitives 6.2.0",
- "sp1-recursion-executor",
- "sp1-recursion-machine",
- "strum 0.27.2",
- "substrate-bn-succinct-rs",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sp1-verifier-legacy"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556d7132484a0b5bb1b2b1d23c5a9b87105fd1727adeb84d383ae8976c81390"
-dependencies = [
- "bincode",
- "blake3",
- "cfg-if",
- "dirs",
- "hex",
- "lazy_static",
- "serde",
- "sha2 0.10.9",
- "slop-algebra",
- "slop-challenger",
- "slop-primitives",
- "slop-symmetric",
- "sp1-hypercube",
- "sp1-primitives 6.2.0",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum 0.27.2",
@@ -4061,8 +3873,8 @@ dependencies = [
  "rand 0.8.6",
  "sha2 0.10.9",
  "slop-algebra",
- "sp1-lib 6.2.0",
- "sp1-primitives 6.2.0",
+ "sp1-lib",
+ "sp1-primitives",
 ]
 
 [[package]]
@@ -4191,23 +4003,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "substrate-bn-succinct"
-version = "0.6.0-v5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
-dependencies = [
- "bytemuck",
- "byteorder",
- "cfg-if",
- "crunchy",
- "lazy_static",
- "num-bigint 0.4.6",
- "rand 0.8.6",
- "rustc-hex",
- "sp1-lib 5.2.4",
 ]
 
 [[package]]

--- a/charms-spell-checker/src/lib.rs
+++ b/charms-spell-checker/src/lib.rs
@@ -13,7 +13,7 @@ pub fn main() {
     sp1_zkvm::io::commit_slice(output_vec.as_slice());
 }
 
-pub fn run(input: SpellProverInput) -> (String, NormalizedSpell) {
+pub fn run(input: SpellProverInput) -> ([u8; 32], NormalizedSpell) {
     let SpellProverInput {
         self_spell_vk,
         prev_txs,

--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -836,6 +836,7 @@ name = "charms-lib"
 version = "15.0.0"
 dependencies = [
  "charms-client",
+ "hex-literal",
 ]
 
 [[package]]

--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -810,10 +810,8 @@ dependencies = [
  "serde",
  "serde_with 3.20.0",
  "sha2 0.10.9",
- "sp1-primitives 6.2.1",
- "sp1-verifier 5.2.4",
- "sp1-verifier 6.2.1",
- "sp1-verifier-legacy",
+ "sp1-primitives",
+ "sp1-verifier",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tracing",
@@ -1496,7 +1494,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2943,23 +2940,8 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "serde",
-]
-
-[[package]]
-name = "p3-baby-bear"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7521838ecab2ddf4f7bc4ceebad06ec02414729598485c1ada516c39900820e8"
-dependencies = [
- "num-bigint 0.4.6",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
+ "p3-field",
+ "p3-matrix",
  "serde",
 ]
 
@@ -2971,10 +2953,10 @@ checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version",
  "serde",
@@ -2988,9 +2970,9 @@ checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
 dependencies = [
  "ff",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "serde",
 ]
@@ -3001,10 +2983,10 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -3017,23 +2999,10 @@ checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
  "serde",
-]
-
-[[package]]
-name = "p3-dft"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46414daedd796f1eefcdc1811c0484e4bced5729486b6eaba9521c572c76761a"
-dependencies = [
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "tracing",
 ]
 
 [[package]]
@@ -3042,25 +3011,11 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "tracing",
-]
-
-[[package]]
-name = "p3-field"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48948a0516b349e9d1cdb95e7236a6ee010c44e68c5cc78b4b92bf1c4022a0d9"
-dependencies = [
- "itertools 0.12.1",
- "num-bigint 0.4.6",
- "num-traits",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -3072,7 +3027,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
  "num-traits",
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "rand 0.8.6",
  "serde",
 ]
@@ -3086,12 +3041,12 @@ dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
  "p3-interpolation",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
 ]
@@ -3102,9 +3057,9 @@ version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
 dependencies = [
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
 ]
 
 [[package]]
@@ -3115,28 +3070,13 @@ checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-poseidon2 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
  "rand 0.8.6",
  "rustc_version",
  "serde",
-]
-
-[[package]]
-name = "p3-matrix"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4de3f373589477cb735ea58e125898ed20935e03664b4614c7fac258b3c42f"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
- "p3-maybe-rayon 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
- "tracing",
 ]
 
 [[package]]
@@ -3146,19 +3086,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
  "rand 0.8.6",
  "serde",
  "tracing",
 ]
-
-[[package]]
-name = "p3-maybe-rayon"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3968ad1160310296eb04f91a5f4edfa38fe1d6b2b8cd6b5c64e6f9b7370979e"
 
 [[package]]
 name = "p3-maybe-rayon"
@@ -3171,31 +3105,16 @@ dependencies = [
 
 [[package]]
 name = "p3-mds"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2356b1ed0add6d5dfbf7a338ce534a6fde827374394a52cec16a0840af6e97c9"
-dependencies = [
- "itertools 0.12.1",
- "p3-dft 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-matrix 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "p3-util 0.2.3-succinct",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "p3-mds"
 version = "0.3.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
 dependencies = [
  "itertools 0.12.1",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
  "rand 0.8.6",
 ]
 
@@ -3207,27 +3126,13 @@ checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-poseidon2"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1eec7e1b6900581bedd95e76e1ef4975608dd55be9872c9d257a8a9651c3a"
-dependencies = [
- "gcd",
- "p3-field 0.2.3-succinct",
- "p3-mds 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "rand 0.8.6",
- "serde",
 ]
 
 [[package]]
@@ -3237,21 +3142,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
 dependencies = [
  "gcd",
- "p3-field 0.3.3-succinct",
- "p3-mds 0.3.3-succinct",
- "p3-symmetric 0.3.3-succinct",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
  "rand 0.8.6",
- "serde",
-]
-
-[[package]]
-name = "p3-symmetric"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb439bea1d822623b41ff4b51e3309e80d13cadf8b86d16ffd5e6efb9fdc360"
-dependencies = [
- "itertools 0.12.1",
- "p3-field 0.2.3-succinct",
  "serde",
 ]
 
@@ -3262,7 +3156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
 dependencies = [
  "itertools 0.12.1",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -3276,22 +3170,13 @@ dependencies = [
  "p3-air",
  "p3-challenger",
  "p3-commit",
- "p3-dft 0.3.3-succinct",
- "p3-field 0.3.3-succinct",
- "p3-matrix 0.3.3-succinct",
- "p3-maybe-rayon 0.3.3-succinct",
- "p3-util 0.3.3-succinct",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
  "serde",
  "tracing",
-]
-
-[[package]]
-name = "p3-util"
-version = "0.2.3-succinct"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c2c2010678b9332b563eaa38364915b585c1a94b5ca61e2c7541c087ddda5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -4200,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a473c3a06b466dd0708829415a8a9fab451740da066e07862c8c098904aaad6"
 dependencies = [
  "itertools 0.14.0",
- "p3-field 0.3.3-succinct",
+ "p3-field",
  "serde",
 ]
 
@@ -4222,7 +4107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c830173902ff1d5fcb2fa8f40ef34c7d68685059a99a6b9ef91be4bb252abd"
 dependencies = [
  "lazy_static",
- "p3-baby-bear 0.3.3-succinct",
+ "p3-baby-bear",
  "serde",
  "slop-algebra",
  "slop-challenger",
@@ -4325,7 +4210,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b3439e560ad36f22860c1754e2d6b8715a26dd94fd0acd46a8b07be61add7f"
 dependencies = [
- "p3-dft 0.3.3-succinct",
+ "p3-dft",
  "serde",
  "slop-algebra",
  "slop-alloc",
@@ -4412,7 +4297,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44c7beb600f1e47c43c2745711cf412872999b1ce6a44b8fb5683cd0b1a64a2"
 dependencies = [
- "p3-matrix 0.3.3-succinct",
+ "p3-matrix",
 ]
 
 [[package]]
@@ -4421,7 +4306,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a2e15a4db7cbc703c203c1ea00d5a889bf3ff9646e8cfd7076ef584ebca441"
 dependencies = [
- "p3-maybe-rayon 0.3.3-succinct",
+ "p3-maybe-rayon",
 ]
 
 [[package]]
@@ -4477,7 +4362,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c956b11fff1b8a071fa4ba982dc35e458cff1620dc7b33d9cf22d8df30895f79"
 dependencies = [
- "p3-poseidon2 0.3.3-succinct",
+ "p3-poseidon2",
 ]
 
 [[package]]
@@ -4536,7 +4421,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955145ad6e3a1d083a428f9274071cfbb44c3b29013aae9d6c4c29fb7328cfc0"
 dependencies = [
- "p3-symmetric 0.3.3-succinct",
+ "p3-symmetric",
 ]
 
 [[package]]
@@ -4574,7 +4459,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ce2c30637af6348960554f9aea4cebce7eb172f173f2187892fcac5cceb3729"
 dependencies = [
- "p3-util 0.3.3-succinct",
+ "p3-util",
  "tracing-forest",
  "tracing-subscriber",
 ]
@@ -4678,45 +4563,13 @@ dependencies = [
  "slop-uni-stark",
  "slop-whir",
  "sp1-derive",
- "sp1-primitives 6.2.1",
+ "sp1-primitives",
  "struct-reflection",
  "strum 0.27.2",
  "thiserror 1.0.69",
  "thousands",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
-dependencies = [
- "bincode 1.3.3",
- "elliptic-curve",
- "serde",
- "sp1-primitives 5.2.4",
-]
-
-[[package]]
-name = "sp1-primitives"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
-dependencies = [
- "bincode 1.3.3",
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "num-bigint 0.4.6",
- "p3-baby-bear 0.2.3-succinct",
- "p3-field 0.2.3-succinct",
- "p3-poseidon2 0.2.3-succinct",
- "p3-symmetric 0.2.3-succinct",
- "serde",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4783,25 +4636,10 @@ dependencies = [
  "slop-symmetric",
  "sp1-derive",
  "sp1-hypercube",
- "sp1-primitives 6.2.1",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "strum 0.27.2",
  "tracing",
-]
-
-[[package]]
-name = "sp1-verifier"
-version = "5.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
-dependencies = [
- "blake3",
- "cfg-if",
- "hex",
- "lazy_static",
- "sha2 0.10.9",
- "substrate-bn-succinct",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4823,34 +4661,7 @@ dependencies = [
  "slop-primitives",
  "slop-symmetric",
  "sp1-hypercube",
- "sp1-primitives 6.2.1",
- "sp1-recursion-executor",
- "sp1-recursion-machine",
- "strum 0.27.2",
- "substrate-bn-succinct-rs",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sp1-verifier-legacy"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556d7132484a0b5bb1b2b1d23c5a9b87105fd1727adeb84d383ae8976c81390"
-dependencies = [
- "bincode 1.3.3",
- "blake3",
- "cfg-if",
- "dirs",
- "hex",
- "lazy_static",
- "serde",
- "sha2 0.10.9",
- "slop-algebra",
- "slop-challenger",
- "slop-primitives",
- "slop-symmetric",
- "sp1-hypercube",
- "sp1-primitives 6.2.1",
+ "sp1-primitives",
  "sp1-recursion-executor",
  "sp1-recursion-machine",
  "strum 0.27.2",
@@ -5003,23 +4814,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "substrate-bn-succinct"
-version = "0.6.0-v5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
-dependencies = [
- "bytemuck",
- "byteorder",
- "cfg-if",
- "crunchy",
- "lazy_static",
- "num-bigint 0.4.6",
- "rand 0.8.6",
- "rustc-hex",
- "sp1-lib",
 ]
 
 [[package]]

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -340,7 +340,7 @@ fn verify_spell_locally(tx_hex: &str, mock: bool) -> anyhow::Result<NormalizedSp
         .map_err(|e| anyhow!("Input error: parsing tx: {}", e))?
         .into();
 
-    let spell = committed_normalized_spell(SPELL_VK, &tx, mock).map_err(|e| {
+    let spell = committed_normalized_spell(&SPELL_VK, &tx, mock).map_err(|e| {
         if e.is::<UnsupportedSpellVersion>() {
             e
         } else {

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -499,8 +499,8 @@ async fn addresses_impl(tx_in_0: String, out_is: Vec<u32>) -> anyhow::Result<Add
 /// the canister's BIP-340/secp256k1 Schnorr chain key under derivation path
 /// `[b"sign"]`. Returns the hex-encoded signature.
 async fn sign_script_pubkeys(script_pubkeys: &BTreeMap<u32, String>) -> anyhow::Result<String> {
-    let message_bytes =
-        util::write(script_pubkeys).context("System error: serializing script_pubkeys for signing")?;
+    let message_bytes = util::write(script_pubkeys)
+        .context("System error: serializing script_pubkeys for signing")?;
     let message_hash = bitcoin::hashes::sha256::Hash::hash(&message_bytes)
         .to_byte_array()
         .to_vec();

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -179,8 +179,7 @@ fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
 
 #[cfg(not(unix))]
 fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
-    fs::write(path, contents)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -262,9 +261,8 @@ fn read_public_key(path: &Path) -> Result<[u8; 32]> {
         .with_context(|| format!("failed to read public key file: {}", path.display()))?;
     let s = s.trim();
     let pk_hex = if s.starts_with('{') {
-        let kp: AppKeypair = serde_json::from_str(s).with_context(|| {
-            format!("failed to parse keypair JSON: {}", path.display())
-        })?;
+        let kp: AppKeypair = serde_json::from_str(s)
+            .with_context(|| format!("failed to parse keypair JSON: {}", path.display()))?;
         kp.public_key
     } else {
         s.trim_start_matches("0x").to_string()

--- a/src/cli/spell.rs
+++ b/src/cli/spell.rs
@@ -42,12 +42,12 @@ impl SpellCli {
                 "mock": true,
                 "prover": is_prover,
                 "version": CURRENT_VERSION,
-                "vk": SPELL_VK.to_string(),
+                "vk": charms_client::tx::vk_hex(&SPELL_VK),
             }),
             false => json!({
                 "prover": is_prover,
                 "version": CURRENT_VERSION,
-                "vk": SPELL_VK.to_string(),
+                "vk": charms_client::tx::vk_hex(&SPELL_VK),
             }),
         };
 
@@ -142,7 +142,7 @@ impl Prove for SpellCli {
                 &prove_request.spell,
                 &prove_request.prev_txs,
                 app_input,
-                SPELL_VK,
+                &SPELL_VK,
                 &prove_request.tx_ins_beamed_source_utxos,
                 None,
             )?;
@@ -235,7 +235,7 @@ impl Check for SpellCli {
             .unwrap_or_default();
         ensure_no_orphan_versioned_apps(&norm_spell)?;
 
-        let prev_spells = charms_client::prev_spells(&prev_txs, SPELL_VK, &norm_spell)?;
+        let prev_spells = charms_client::prev_spells(&prev_txs, &SPELL_VK, &norm_spell)?;
 
         let charms_tx = charms_client::to_tx(
             &norm_spell,
@@ -269,7 +269,7 @@ impl Check for SpellCli {
             &norm_spell,
             &prev_txs,
             app_input,
-            SPELL_VK,
+            &SPELL_VK,
             &tx_ins_beamed_source_utxos,
             None,
         )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,6 @@ mod test {
             .await
             .unwrap();
         let s = pk.verifying_key().bytes32();
-        assert_eq!(SPELL_VK, s.as_str());
+        assert_eq!(charms_client::tx::vk_hex(&SPELL_VK)[2..], s[2..]);
     }
 }

--- a/src/spell/prove.rs
+++ b/src/spell/prove.rs
@@ -95,7 +95,7 @@ impl Prover {
         let (spell_checker_pk, spell_checker_vk) = prover_client.get().setup(SPELL_CHECKER_BINARY);
         assert_eq!(crate::SPELL_CHECKER_VK, spell_checker_vk.hash_u32());
         let (proof_wrapper_pk, vk) = prover_client.get().setup(PROOF_WRAPPER_BINARY);
-        assert_eq!(SPELL_VK, vk.bytes32().as_str());
+        assert_eq!(charms_client::tx::vk_hex(&SPELL_VK), vk.bytes32());
         Self {
             spell_prover_client: app_prover.sp1_client.clone(),
             wrapper_prover_client: prover_client,
@@ -132,7 +132,7 @@ impl Prove for Prover {
         };
 
         let prover_input = SpellProverInput {
-            self_spell_vk: SPELL_VK.to_string(),
+            self_spell_vk: SPELL_VK,
             prev_txs,
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
@@ -198,7 +198,7 @@ impl Prove for MockProver {
 
         // Run the zkVM guest program (charms-spell-checker) instead of running apps directly
         let prover_input = SpellProverInput {
-            self_spell_vk: SPELL_VK.to_string(),
+            self_spell_vk: SPELL_VK,
             prev_txs,
             spell: norm_spell.clone(),
             tx_ins_beamed_source_utxos,
@@ -224,7 +224,8 @@ impl Prove for MockProver {
         let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
         let pk = load_pk()?;
 
-        let committed_data = util::write(&(MOCK_SPELL_VK, norm_spell.clone()))?;
+        let committed_data =
+            charms_client::tx::to_serialized_pv(norm_spell.version, &MOCK_SPELL_VK, &norm_spell);
 
         let field_elements = Sha256::digest(&committed_data)
             .to_field_elements()

--- a/src/spell/prove_spell_tx.rs
+++ b/src/spell/prove_spell_tx.rs
@@ -2,10 +2,10 @@ use super::{
     prove::Prove,
     request::{CharmsFee, ProveRequest},
 };
-#[cfg(not(feature = "prover"))]
-use crate::utils::retry;
 #[cfg(feature = "prover")]
 use crate::tx::scrolls_bitcoin;
+#[cfg(not(feature = "prover"))]
+use crate::utils::retry;
 use crate::{
     cli::{charms_fee_settings, prove_impl},
     tx::{bitcoin_tx, cardano_tx},
@@ -89,11 +89,9 @@ impl ProveSpellTxImpl {
         &self,
         mut prove_request: ProveRequest,
     ) -> anyhow::Result<Vec<Tx>> {
-        let scroll_outputs = scrolls_bitcoin::fill_scroll_outputs(
-            &mut prove_request.spell,
-            prove_request.chain,
-        )
-        .await?;
+        let scroll_outputs =
+            scrolls_bitcoin::fill_scroll_outputs(&mut prove_request.spell, prove_request.chain)
+                .await?;
         let (app_cycles, verified) =
             self.validate_prove_request(&mut prove_request, scroll_outputs.as_ref())?;
         ensure!(verified, "spell verification failed");

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -74,9 +74,7 @@ pub fn ensure_versioned_apps_have_signatures(
         .filter(|(app, _)| norm_spell.versioned_apps.contains_key(&app.vk))
         .filter(|(app, data)| {
             !data.is_empty()
-                || !app_private_inputs
-                    .get(app)
-                    .is_none_or(|w| w.is_empty())
+                || !app_private_inputs.get(app).is_none_or(|w| w.is_empty())
                 || !charms_data::is_simple_transfer(app, tx)
         })
         .map(|(app, _)| &app.vk)
@@ -332,11 +330,8 @@ impl ProveSpellTxImpl {
                 // on the client preflight path -- the prover server fills them in
                 // via `fill_scroll_outputs`, and `check_scroll_outputs` later pins
                 // each `dest` to the canister-signed scriptPubKey.
-                let scroll_indexes: BTreeSet<u32> = norm_spell
-                    .tx
-                    .scrolls
-                    .clone()
-                    .unwrap_or_default();
+                let scroll_indexes: BTreeSet<u32> =
+                    norm_spell.tx.scrolls.clone().unwrap_or_default();
                 ensure!(
                     coin_outs.iter().enumerate().all(|(i, o)| {
                         if scroll_indexes.contains(&(i as u32)) && o.dest.is_empty() {

--- a/src/spell/validate.rs
+++ b/src/spell/validate.rs
@@ -248,7 +248,7 @@ impl ProveSpellTxImpl {
         ensure_all_prev_txs_are_present(&norm_spell, tx_ins_beamed_source_utxos, &prev_txs_by_id)?;
         ensure_unique_spell_inputs(&norm_spell)?;
 
-        let prev_spells = charms_client::prev_spells(prev_txs, SPELL_VK, &norm_spell)?;
+        let prev_spells = charms_client::prev_spells(prev_txs, &SPELL_VK, &norm_spell)?;
 
         let tx = charms_client::to_tx(
             &norm_spell,
@@ -286,7 +286,7 @@ impl ProveSpellTxImpl {
             &norm_spell,
             &prev_txs,
             app_input.clone(),
-            SPELL_VK,
+            &SPELL_VK,
             &tx_ins_beamed_source_utxos,
             scroll_outputs,
         )?;

--- a/src/tx/cardano_tx/mod.rs
+++ b/src/tx/cardano_tx/mod.rs
@@ -342,7 +342,7 @@ pub fn from_spell(
         .map(|tx| {
             Ok((
                 tx.tx_id(),
-                charms_client::tx::extended_normalized_spell(charms_lib::SPELL_VK, spell, tx)?,
+                charms_client::tx::extended_normalized_spell(&charms_lib::SPELL_VK, spell, tx)?,
             ))
         })
         .collect::<anyhow::Result<_>>()?;

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -7,7 +7,7 @@ pub mod scrolls_bitcoin;
 
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn spell(tx: &Tx, mock: bool) -> Option<NormalizedSpell> {
-    charms_client::tx::committed_normalized_spell(SPELL_VK, tx, mock)
+    charms_client::tx::committed_normalized_spell(&SPELL_VK, tx, mock)
         .map_err(|e| {
             tracing::debug!("spell verification failed: {:?}", e);
             e

--- a/src/tx/scrolls_bitcoin.rs
+++ b/src/tx/scrolls_bitcoin.rs
@@ -45,11 +45,10 @@ pub async fn fill_scroll_outputs(
 
     let signed = call_canister_addresses(&tx_in_0, out_is).await?;
 
-    let coins = spell
-        .tx
-        .coins
-        .as_mut()
-        .ok_or_else(|| anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set"))?;
+    let coins =
+        spell.tx.coins.as_mut().ok_or_else(|| {
+            anyhow!("Bitcoin spell with Scrolls outputs must have `tx.coins` set")
+        })?;
     let coins_len = coins.len();
     for (&i, spk_hex) in &signed.script_pubkeys {
         let coin = coins.get_mut(i as usize).ok_or_else(|| {


### PR DESCRIPTION
## Summary

Three commits, on top of `CharmsDev/charms@main` (3308dbd):

- **329629e** — Unify Groth16 verification on `sp1_verifier::Groth16Verifier::verify_gnark_proof`, parameterised by the SP1-version-specific `VK_ROOT_BYTES`. Drop the `sp1-verifier_5` (5.2.4) and `sp1-verifier-legacy` (6.0.2) dependencies; their VK roots are hardcoded as `SP1_V6_0_VK_ROOT` / `SP1_V6_2_VK_ROOT`. A unit test asserts the current-version constant stays in sync with `*sp1_verifier::VK_ROOT_BYTES`. SP1's blake3 fallback is dropped (our spell prover always commits public inputs with SHA256).
- **692db63** — Store spell verification keys as `[u8; 32]` (via `hex_literal::hex!`) and thread `&[u8; 32]` through the verifier (`verify_snark_proof`, `tx::spell_vk`, `EnchantedTx::{extract_and_verify_spell, virtual_spell}`, `committed_normalized_spell`, `extended_normalized_spell`, `prev_spells`, `is_correct`), so `decode_sp1_vkey_hash` is no longer called per-verify. New `tx::vk_hex(&[u8; 32]) -> String` renders the `"0x"`-prefixed hex form at the remaining serialization boundaries.
  - V15 introduces a new public-values wire format: `SpellProverInput.self_spell_vk: [u8; 32]`, `charms_spell_checker::run() -> ([u8; 32], NormalizedSpell)`, and `to_serialized_pv` switches on `spell_version` — V0 keeps SP1-internal `(String, NormalizedSpell)`, V1..=V14 keep CBOR `(String, NormalizedSpell)`, V15+ commits CBOR `([u8; 32], NormalizedSpell)`. Historical proofs verify byte-identically to before.
- **17bb764** — `cargo fmt` cleanup.

## Test plan

- [x] `cargo build --profile=test` (charms workspace, charms-spell-checker, scrolls workspaces)
- [x] `cargo test --workspace --profile=test` (charms)
- [x] `cargo test --profile=test` for scrolls and charms-spell-checker workspaces
- [ ] Rebuild the V15 `charms-spell-checker` / `charms-proof-wrapper` binaries and update `charms_lib::SPELL_VK` to the new value before merging.