### PR TITLE
feat(cli): default app signatures to <wasm-path>.sig.yaml

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -244,11 +244,6 @@ pub fn keygen(out: Option<PathBuf>) -> Result<()> {
     };
 
     let out = out.unwrap_or_else(default_app_key_path);
-    ensure!(
-        !out.exists(),
-        "refusing to overwrite existing keypair at {}; delete it first or pass --out <path>",
-        out.display()
-    );
     if out.parent().is_some_and(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(out.parent().expect("parent path"))
             .with_context(|| format!("failed to create {}", out.parent().unwrap().display()))?;
@@ -263,25 +258,28 @@ pub fn keygen(out: Option<PathBuf>) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
-    use std::os::unix::fs::OpenOptionsExt;
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .with_context(|| format!("failed to open {} for writing", path.display()))?;
     use std::io::Write as _;
+    #[cfg(unix)]
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut opts = fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    opts.mode(0o600);
+
+    let mut file = opts.open(path).map_err(|e| {
+        if e.kind() == io::ErrorKind::AlreadyExists {
+            anyhow!(
+                "refusing to overwrite existing keypair at {}; delete it first or pass --out <path>",
+                path.display()
+            )
+        } else {
+            e.into()
+        }
+    })?;
     file.write_all(contents)
         .with_context(|| format!("failed to write {}", path.display()))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
-    fs::write(path, contents).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -9,7 +9,20 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    str::FromStr as _,
 };
+
+const APP_KEY_FILE: &str = ".charms/app-key.json";
+
+fn default_app_key_path() -> PathBuf {
+    PathBuf::from(APP_KEY_FILE)
+}
+
+fn signatures_path_for_wasm(wasm_path: impl AsRef<Path>) -> PathBuf {
+    let mut path = wasm_path.as_ref().as_os_str().to_os_string();
+    path.push(".sig.yaml");
+    PathBuf::from(path)
+}
 
 pub fn new(name: &str) -> Result<()> {
     if !Command::new("which")
@@ -123,7 +136,27 @@ fn relative_path(from: &Path, to: &Path) -> Result<PathBuf> {
 
 pub fn build() -> Result<()> {
     let bin_path = do_build()?;
+    maybe_auto_sign(&bin_path)?;
     println!("{}", bin_path);
+    Ok(())
+}
+
+fn maybe_auto_sign(wasm_path: &str) -> Result<()> {
+    let key_path = default_app_key_path();
+    if !key_path.exists() {
+        return Ok(());
+    }
+    let (vk, app_sig) = sign_wasm_at(&key_path, Path::new(wasm_path))?;
+    write_signed_wasm(&signatures_path_for_wasm(wasm_path), vk, app_sig)
+}
+
+fn write_signed_wasm(path: &Path, vk: B32, app_sig: AppSignature) -> Result<()> {
+    write_app_signatures(path, &[(vk, app_sig)])?;
+    eprintln!(
+        "signed wasm module; wrote app signature to {} (pass to `charms spell prove \
+         --app-signatures` / `charms spell check --app-signatures`)",
+        path.display()
+    );
     Ok(())
 }
 
@@ -208,18 +241,18 @@ pub fn keygen(out: Option<PathBuf>) -> Result<()> {
         vk: hex::encode(vk),
     };
 
-    let s = serde_json::to_string_pretty(&keypair)?;
-    match out {
-        Some(p) => write_secret_file(&p, s.as_bytes())?,
-        None => {
-            eprintln!(
-                "WARNING: writing the secret key to stdout. Capture it directly (e.g. \
-                 `... > key.json`) and protect the file; do not paste into chats or logs. \
-                 Prefer `--out <FILE>` (which writes with mode 0600 on Unix)."
-            );
-            println!("{}", s);
-        }
+    let out = out.unwrap_or_else(default_app_key_path);
+    if out.parent().is_some_and(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(out.parent().expect("parent path"))
+            .with_context(|| format!("failed to create {}", out.parent().unwrap().display()))?;
     }
+    let s = serde_json::to_string_pretty(&keypair)?;
+    write_secret_file(&out, s.as_bytes())?;
+    eprintln!(
+        "wrote app signing keypair to {} (keep this file secret; do not commit it to source \
+         control)",
+        out.display()
+    );
     Ok(())
 }
 
@@ -246,14 +279,42 @@ fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
 }
 
 pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<()> {
+    let wasm_path = match bin {
+        Some(p) => p,
+        None => {
+            let path = wasm_path()?;
+            ensure!(
+                Path::new(&path).exists(),
+                "wasm binary not found at {path}; run `charms app build` first or pass --bin"
+            );
+            PathBuf::from(path)
+        }
+    };
+    let (vk, app_sig) = sign_wasm_at(&key, &wasm_path)?;
+    match out {
+        Some(p) => {
+            if p.extension().is_some_and(|ext| ext == "yaml" || ext == "yml") {
+                write_signed_wasm(&p, vk, app_sig)?;
+            } else {
+                let s = serde_json::to_string_pretty(&app_sig)?;
+                fs::write(&p, s.as_bytes())
+                    .with_context(|| format!("failed to write {}", p.display()))?;
+            }
+        }
+        None => write_signed_wasm(&signatures_path_for_wasm(&wasm_path), vk, app_sig)?,
+    }
+    Ok(())
+}
+
+fn sign_wasm_at(key_path: &Path, wasm_path: &Path) -> Result<(B32, AppSignature)> {
     let secp = Secp256k1::new();
-    let keypair = load_keypair(&secp, &key)?;
+    let keypair = load_keypair(&secp, key_path)?;
+    let app_keypair = read_app_keypair(key_path)?;
+    let vk = B32::from_str(&app_keypair.vk).context("invalid vk in keypair file")?;
     let (xonly_pk, _parity) = keypair.x_only_public_key();
 
-    let binary = match bin {
-        Some(p) => fs::read(p)?,
-        None => fs::read(do_build()?)?,
-    };
+    let binary = fs::read(wasm_path)
+        .with_context(|| format!("failed to read wasm binary: {}", wasm_path.display()))?;
     let binary_hash: [u8; 32] = Sha256::digest(&binary).into();
     let msg = Message::from_digest(binary_hash);
 
@@ -267,22 +328,35 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
         public_key: B32(xonly_pk.serialize()),
         signature: *signature.as_ref(),
     };
-    let s = serde_json::to_string_pretty(&app_sig)?;
-    match out {
-        Some(p) => fs::write(p, s.as_bytes())?,
-        None => println!("{}", s),
+    Ok((vk, app_sig))
+}
+
+fn write_app_signatures(path: &Path, entries: &[(B32, AppSignature)]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
     }
+    let map: BTreeMap<B32, AppSignature> = entries.iter().cloned().collect();
+    let s = serde_yaml::to_string(&map)?;
+    fs::write(path, s.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
+}
+
+fn read_app_keypair(path: &Path) -> Result<AppKeypair> {
+    let s = fs::read_to_string(path)
+        .with_context(|| format!("failed to read keypair file: {}", path.display()))?;
+    serde_json::from_str(&s)
+        .with_context(|| format!("failed to parse keypair JSON: {}", path.display()))
 }
 
 /// Load a keypair, deriving the verifying key from the on-disk secret key and rejecting
 /// inconsistent `public_key` / `vk` fields. Catches accidental edits or swaps in the file
 /// before any signed material is produced.
 fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Result<Keypair> {
-    let s = fs::read_to_string(path)
-        .with_context(|| format!("failed to read keypair file: {}", path.display()))?;
-    let kp: AppKeypair = serde_json::from_str(&s)
-        .with_context(|| format!("failed to parse keypair JSON: {}", path.display()))?;
+    let kp = read_app_keypair(path)?;
     let secret_bytes = hex::decode(&kp.secret_key).context("invalid hex in secret_key")?;
     let sk = SecretKey::from_slice(&secret_bytes)
         .map_err(|e| anyhow!("invalid secp256k1 secret key: {}", e))?;
@@ -366,6 +440,31 @@ mod tests {
         let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let member = repo_root.join("charms-data");
         assert_eq!(relative_path(&member, &repo_root)?, PathBuf::from(".."));
+        Ok(())
+    }
+
+    #[test]
+    fn signatures_path_for_wasm_appends_suffix() {
+        assert_eq!(
+            signatures_path_for_wasm("./target/wasm32-wasip1/release/myapp.wasm"),
+            PathBuf::from("./target/wasm32-wasip1/release/myapp.wasm.sig.yaml")
+        );
+    }
+
+    #[test]
+    fn write_app_signatures_roundtrip() -> Result<()> {
+        let dir = std::env::temp_dir().join(format!("charms-app-test-{}", std::process::id()));
+        fs::create_dir_all(&dir)?;
+        let path = dir.join("app-signatures.yaml");
+        let vk = B32([1u8; 32]);
+        let sig = AppSignature {
+            public_key: B32([2u8; 32]),
+            signature: [3u8; 64],
+        };
+        write_app_signatures(&path, &[(vk.clone(), sig.clone())])?;
+        let parsed = read_app_signatures(&path)?;
+        assert_eq!(parsed.get(&vk), Some(&sig));
+        fs::remove_dir_all(dir)?;
         Ok(())
     }
 }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -9,7 +9,6 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
     process::{Command, Stdio},
-    str::FromStr as _,
 };
 
 const APP_KEY_FILE: &str = ".charms/app-key.json";
@@ -142,11 +141,14 @@ pub fn build() -> Result<()> {
 }
 
 fn maybe_auto_sign(wasm_path: &str) -> Result<()> {
-    let key_path = default_app_key_path();
+    maybe_auto_sign_with_key(&default_app_key_path(), wasm_path)
+}
+
+fn maybe_auto_sign_with_key(key_path: &Path, wasm_path: &str) -> Result<()> {
     if !key_path.exists() {
         return Ok(());
     }
-    let (vk, app_sig) = sign_wasm_at(&key_path, Path::new(wasm_path))?;
+    let (vk, app_sig) = sign_wasm_at(key_path, Path::new(wasm_path))?;
     write_signed_wasm(&signatures_path_for_wasm(wasm_path), vk, app_sig)
 }
 
@@ -242,6 +244,11 @@ pub fn keygen(out: Option<PathBuf>) -> Result<()> {
     };
 
     let out = out.unwrap_or_else(default_app_key_path);
+    ensure!(
+        !out.exists(),
+        "refusing to overwrite existing keypair at {}; delete it first or pass --out <path>",
+        out.display()
+    );
     if out.parent().is_some_and(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(out.parent().expect("parent path"))
             .with_context(|| format!("failed to create {}", out.parent().unwrap().display()))?;
@@ -308,9 +315,7 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
 
 fn sign_wasm_at(key_path: &Path, wasm_path: &Path) -> Result<(B32, AppSignature)> {
     let secp = Secp256k1::new();
-    let keypair = load_keypair(&secp, key_path)?;
-    let app_keypair = read_app_keypair(key_path)?;
-    let vk = B32::from_str(&app_keypair.vk).context("invalid vk in keypair file")?;
+    let (keypair, vk) = load_keypair(&secp, key_path)?;
     let (xonly_pk, _parity) = keypair.x_only_public_key();
 
     let binary = fs::read(wasm_path)
@@ -355,7 +360,7 @@ fn read_app_keypair(path: &Path) -> Result<AppKeypair> {
 /// Load a keypair, deriving the verifying key from the on-disk secret key and rejecting
 /// inconsistent `public_key` / `vk` fields. Catches accidental edits or swaps in the file
 /// before any signed material is produced.
-fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Result<Keypair> {
+fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Result<(Keypair, B32)> {
     let kp = read_app_keypair(path)?;
     let secret_bytes = hex::decode(&kp.secret_key).context("invalid hex in secret_key")?;
     let sk = SecretKey::from_slice(&secret_bytes)
@@ -383,7 +388,7 @@ fn load_keypair<C: secp256k1::Signing>(secp: &Secp256k1<C>, path: &Path) -> Resu
         hex::encode(derived_vk)
     );
 
-    Ok(keypair)
+    Ok((keypair, B32(derived_vk)))
 }
 
 /// Read a BIP-340 x-only public key from `path`. Accepts either:
@@ -419,6 +424,18 @@ pub fn read_app_signatures(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        let n = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("{prefix}-{n}-{}", std::process::id()))
+    }
+
+    fn remove_test_dir(dir: &Path) {
+        let _ = fs::remove_dir_all(dir);
+    }
 
     #[test]
     fn find_workspace_root_from_member() -> Result<()> {
@@ -453,7 +470,7 @@ mod tests {
 
     #[test]
     fn write_app_signatures_roundtrip() -> Result<()> {
-        let dir = std::env::temp_dir().join(format!("charms-app-test-{}", std::process::id()));
+        let dir = unique_test_dir("charms-app-signatures");
         fs::create_dir_all(&dir)?;
         let path = dir.join("app-signatures.yaml");
         let vk = B32([1u8; 32]);
@@ -464,7 +481,56 @@ mod tests {
         write_app_signatures(&path, &[(vk.clone(), sig.clone())])?;
         let parsed = read_app_signatures(&path)?;
         assert_eq!(parsed.get(&vk), Some(&sig));
-        fs::remove_dir_all(dir)?;
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn maybe_auto_sign_writes_signatures_yaml() -> Result<()> {
+        let dir = unique_test_dir("charms-auto-sign");
+        fs::create_dir_all(&dir)?;
+        let key_path = dir.join("app-key.json");
+        let wasm_path = dir.join("app.wasm");
+        fs::write(&wasm_path, b"test wasm binary")?;
+        keygen(Some(key_path.clone()))?;
+
+        maybe_auto_sign_with_key(&key_path, wasm_path.to_str().unwrap())?;
+
+        let sig_path = signatures_path_for_wasm(&wasm_path);
+        let parsed = read_app_signatures(&sig_path)?;
+        assert_eq!(parsed.len(), 1);
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn maybe_auto_sign_skips_when_key_missing() -> Result<()> {
+        let dir = unique_test_dir("charms-auto-sign-skip");
+        fs::create_dir_all(&dir)?;
+        let wasm_path = dir.join("app.wasm");
+        fs::write(&wasm_path, b"test wasm binary")?;
+        let key_path = dir.join("missing-key.json");
+        let sig_path = signatures_path_for_wasm(&wasm_path);
+
+        maybe_auto_sign_with_key(&key_path, wasm_path.to_str().unwrap())?;
+
+        assert!(!sig_path.exists());
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn keygen_refuses_to_overwrite_existing_key() -> Result<()> {
+        let dir = unique_test_dir("charms-keygen-overwrite");
+        fs::create_dir_all(&dir)?;
+        let key_path = dir.join("app-key.json");
+        keygen(Some(key_path.clone()))?;
+        let err = keygen(Some(key_path)).unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to overwrite"),
+            "unexpected error: {err}"
+        );
+        remove_test_dir(&dir);
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -395,6 +395,7 @@ pub enum AppCommands {
         bin: Option<PathBuf>,
 
         /// Path to write the signature to (default: `<wasm-path>.sig.yaml`).
+        /// `.yaml`/`.yml` extensions write a VK-keyed YAML map; other extensions write JSON.
         #[arg(long)]
         out: Option<PathBuf>,
     },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -347,7 +347,8 @@ pub enum AppCommands {
 
     /// Build the app to WebAssembly (wasm32-wasip1).
     ///
-    /// Prints the path to the built .wasm binary to stdout.
+    /// Prints the path to the built .wasm binary to stdout. If `.charms/app-key.json`
+    /// exists (from `app keygen`), also signs the binary and writes `<wasm-path>.sig.yaml`.
     Build,
 
     /// Show verification key (VK) for an app.
@@ -369,30 +370,31 @@ pub enum AppCommands {
     /// Generate a new BIP-340 Schnorr signing keypair (secp256k1) for a versioned app.
     ///
     /// Writes a JSON object with hex-encoded `public_key`, `secret_key`, and computed `vk`
-    /// (SHA-256 of public key) to `--out` (or stdout if omitted).
+    /// (SHA-256 of public key) to `--out` (default: `.charms/app-key.json`).
     ///
-    /// **Security:** the `secret_key` field is sensitive. Prefer `--out` to a file you
-    /// trust; do not commit it to source control or paste it into chats/logs.
+    /// **Security:** the `secret_key` field is sensitive. Do not commit it to source
+    /// control or paste it into chats/logs.
     Keygen {
-        /// Path to write the keypair JSON to. Prints to stdout if omitted.
+        /// Path to write the keypair JSON to (default: `.charms/app-key.json`).
         #[arg(long)]
         out: Option<PathBuf>,
     },
 
     /// Sign a Wasm binary's SHA-256 hash with an app signing key.
     ///
-    /// Writes a JSON `{public_key, signature}` (hex) to `--out` (or stdout). The signature
-    /// is a BIP-340 Schnorr signature (over secp256k1) of the binary's SHA-256 hash.
+    /// The signature is a BIP-340 Schnorr signature (over secp256k1) of the binary's
+    /// SHA-256 hash. By default writes `<wasm-path>.sig.yaml` (same as `app build`
+    /// auto-signing).
     Sign {
-        /// Path to the keypair JSON produced by `app keygen`.
-        #[arg(long)]
+        /// Path to the keypair JSON produced by `app keygen` (default: `.charms/app-key.json`).
+        #[arg(long, default_value = ".charms/app-key.json")]
         key: PathBuf,
 
-        /// Path to the Wasm binary to sign (builds the app if omitted).
+        /// Path to the Wasm binary to sign (uses the release build output if omitted).
         #[arg(long)]
         bin: Option<PathBuf>,
 
-        /// Path to write the signature JSON to. Prints to stdout if omitted.
+        /// Path to write the signature to (default: `<wasm-path>.sig.yaml`).
         #[arg(long)]
         out: Option<PathBuf>,
     },


### PR DESCRIPTION
## Summary

- Write app signatures next to the built wasm binary as `<wasm-path>.sig.yaml` instead of a fixed `.charms/app-signatures.yaml` path
- Auto-sign on `charms app build` when `.charms/app-key.json` exists (from `app keygen`)
- Default `app keygen` output to `.charms/app-key.json`
- Align `app sign` defaults and CLI help text with the new layout

## Test plan

- [x] `cargo test cli::app::tests`
- [ ] `charms app keygen` writes `.charms/app-key.json`
- [ ] `charms app build` writes `<wasm-path>.sig.yaml` when key exists
- [ ] `charms app sign` without `--out` writes `<wasm-path>.sig.yaml`