### PR TITLE
feat(cli): app vk from app-key.json and app verify command

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -178,19 +178,20 @@ fn resolve_app_vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<B32>
                 let binary = fs::read(path)?;
                 Ok(B32(Sha256::digest(&binary).into()))
             }
-            None => {
-                let key_path = default_app_key_path();
-                if key_path.exists() {
-                    let secp = Secp256k1::new();
-                    let (_, vk) = load_keypair(&secp, &key_path)?;
-                    return Ok(vk);
-                }
-                let bin_path = do_build()?;
-                let binary = fs::read(bin_path)?;
-                Ok(B32(Sha256::digest(&binary).into()))
-            }
+            None => app_vk_from_key_or_wasm(&default_app_key_path()),
         },
     }
+}
+
+fn app_vk_from_key_or_wasm(key_path: &Path) -> Result<B32> {
+    if key_path.exists() {
+        let secp = Secp256k1::signing_only();
+        let (_, vk) = load_keypair(&secp, key_path)?;
+        return Ok(vk);
+    }
+    let bin_path = do_build()?;
+    let binary = fs::read(bin_path)?;
+    Ok(B32(Sha256::digest(&binary).into()))
 }
 
 pub fn vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<()> {
@@ -344,7 +345,7 @@ fn verify_wasm_at(wasm_path: &Path, sig_path: &Path) -> Result<()> {
     let binary_hash: [u8; 32] = Sha256::digest(&binary).into();
     let msg = Message::from_digest(binary_hash);
 
-    let signatures = read_app_signatures(sig_path)?;
+    let signatures = read_signature_entries(sig_path)?;
     ensure!(
         !signatures.is_empty(),
         "no signatures found in {}",
@@ -475,12 +476,22 @@ fn read_public_key(path: &Path) -> Result<[u8; 32]> {
         .map_err(|_| anyhow!("public key must be 32 bytes (hex-encoded as 64 characters)"))
 }
 
-pub fn read_app_signatures(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {
+fn read_signature_entries(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {
     let bytes = fs::read(path)
-        .with_context(|| format!("failed to read app signatures file: {}", path.display()))?;
+        .with_context(|| format!("failed to read signature file: {}", path.display()))?;
+    if path.extension().is_some_and(|ext| ext == "json") {
+        let app_sig: AppSignature = serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse JSON signature: {}", path.display()))?;
+        let vk = B32(Sha256::digest(&app_sig.public_key.0).into());
+        return Ok(BTreeMap::from([(vk, app_sig)]));
+    }
     let map: BTreeMap<B32, AppSignature> = serde_yaml::from_slice(&bytes)
         .with_context(|| format!("failed to parse app signatures: {}", path.display()))?;
     Ok(map)
+}
+
+pub fn read_app_signatures(path: &Path) -> Result<BTreeMap<B32, AppSignature>> {
+    read_signature_entries(path)
 }
 
 #[cfg(test)]
@@ -591,11 +602,7 @@ mod tests {
         keygen(Some(key_path.clone()))?;
         let expected_vk = B32::from_str(&read_app_keypair(&key_path)?.vk)?;
 
-        let prev_cwd = std::env::current_dir()?;
-        std::env::set_current_dir(&dir)?;
-        let vk = resolve_app_vk(None, None)?;
-        std::env::set_current_dir(prev_cwd)?;
-
+        let vk = app_vk_from_key_or_wasm(&key_path)?;
         assert_eq!(vk, expected_vk);
         remove_test_dir(&dir);
         Ok(())
@@ -612,6 +619,22 @@ mod tests {
         sign(key_path, Some(wasm_path.clone()), None)?;
 
         verify(Some(wasm_path.clone()), None)?;
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_accepts_json_signature_from_sign() -> Result<()> {
+        let dir = unique_test_dir("charms-verify-json");
+        fs::create_dir_all(&dir)?;
+        let key_path = dir.join("app-key.json");
+        let wasm_path = dir.join("app.wasm");
+        let sig_path = dir.join("sig.json");
+        fs::write(&wasm_path, b"test wasm binary")?;
+        keygen(Some(key_path.clone()))?;
+        sign(key_path, Some(wasm_path.clone()), Some(sig_path.clone()))?;
+
+        verify(Some(wasm_path), Some(sig_path))?;
         remove_test_dir(&dir);
         Ok(())
     }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, anyhow, ensure};
 use charms_app_runner::AppRunner;
 use charms_data::{AppSignature, B32};
-use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
+use secp256k1::{Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey, schnorr};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
@@ -292,18 +292,22 @@ fn write_secret_file(path: &Path, contents: &[u8]) -> Result<()> {
     Ok(())
 }
 
-pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<()> {
-    let wasm_path = match bin {
-        Some(p) => p,
+fn resolve_wasm_path(bin: Option<PathBuf>) -> Result<PathBuf> {
+    match bin {
+        Some(p) => Ok(p),
         None => {
             let path = wasm_path()?;
             ensure!(
                 Path::new(&path).exists(),
                 "wasm binary not found at {path}; run `charms app build` first or pass --bin"
             );
-            PathBuf::from(path)
+            Ok(PathBuf::from(path))
         }
-    };
+    }
+}
+
+pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<()> {
+    let wasm_path = resolve_wasm_path(bin)?;
     let (vk, app_sig) = sign_wasm_at(&key, &wasm_path)?;
     match out {
         Some(p) => {
@@ -318,6 +322,56 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
             }
         }
         None => write_signed_wasm(&signatures_path_for_wasm(&wasm_path), vk, app_sig)?,
+    }
+    Ok(())
+}
+
+pub fn verify(bin: Option<PathBuf>, sig: Option<PathBuf>) -> Result<()> {
+    let wasm_path = resolve_wasm_path(bin)?;
+    let sig_path = sig.unwrap_or_else(|| signatures_path_for_wasm(&wasm_path));
+    verify_wasm_at(&wasm_path, &sig_path)?;
+    eprintln!(
+        "signature verified for {} (signature file: {})",
+        wasm_path.display(),
+        sig_path.display()
+    );
+    Ok(())
+}
+
+fn verify_wasm_at(wasm_path: &Path, sig_path: &Path) -> Result<()> {
+    let binary = fs::read(wasm_path)
+        .with_context(|| format!("failed to read wasm binary: {}", wasm_path.display()))?;
+    let binary_hash: [u8; 32] = Sha256::digest(&binary).into();
+    let msg = Message::from_digest(binary_hash);
+
+    let signatures = read_app_signatures(sig_path)?;
+    ensure!(
+        !signatures.is_empty(),
+        "no signatures found in {}",
+        sig_path.display()
+    );
+
+    let secp = Secp256k1::verification_only();
+    for (vk, app_sig) in &signatures {
+        let pk_hash = B32(Sha256::digest(&app_sig.public_key.0).into());
+        ensure!(
+            pk_hash == *vk,
+            "public key hash does not match VK key in signature file (vk {}, derived {})",
+            vk,
+            pk_hash
+        );
+        let xonly_pk = XOnlyPublicKey::from_slice(&app_sig.public_key.0)
+            .map_err(|e| anyhow!("invalid BIP-340 x-only public key: {}", e))?;
+        let signature = schnorr::Signature::from_slice(&app_sig.signature)
+            .map_err(|e| anyhow!("invalid BIP-340 Schnorr signature: {}", e))?;
+        secp.verify_schnorr(&signature, &msg, &xonly_pk)
+            .map_err(|e| {
+                anyhow!(
+                    "BIP-340 Schnorr signature verification failed for vk {}: {}",
+                    vk,
+                    e
+                )
+            })?;
     }
     Ok(())
 }
@@ -543,6 +597,41 @@ mod tests {
         std::env::set_current_dir(prev_cwd)?;
 
         assert_eq!(vk, expected_vk);
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_accepts_signature_from_sign() -> Result<()> {
+        let dir = unique_test_dir("charms-verify-ok");
+        fs::create_dir_all(&dir)?;
+        let key_path = dir.join("app-key.json");
+        let wasm_path = dir.join("app.wasm");
+        fs::write(&wasm_path, b"test wasm binary")?;
+        keygen(Some(key_path.clone()))?;
+        sign(key_path, Some(wasm_path.clone()), None)?;
+
+        verify(Some(wasm_path.clone()), None)?;
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_rejects_tampered_binary() -> Result<()> {
+        let dir = unique_test_dir("charms-verify-bad-binary");
+        fs::create_dir_all(&dir)?;
+        let key_path = dir.join("app-key.json");
+        let wasm_path = dir.join("app.wasm");
+        fs::write(&wasm_path, b"test wasm binary")?;
+        keygen(Some(key_path.clone()))?;
+        sign(key_path, Some(wasm_path.clone()), None)?;
+
+        fs::write(&wasm_path, b"tampered wasm binary")?;
+        let err = verify(Some(wasm_path), None).unwrap_err();
+        assert!(
+            err.to_string().contains("signature verification failed"),
+            "unexpected error: {err}"
+        );
         remove_test_dir(&dir);
         Ok(())
     }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -162,30 +162,39 @@ fn write_signed_wasm(path: &Path, vk: B32, app_sig: AppSignature) -> Result<()> 
     Ok(())
 }
 
-pub fn vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<()> {
+fn resolve_app_vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<B32> {
     ensure!(
         !(path.is_some() && pubkey.is_some()),
         "pass at most one of <PATH> or --pubkey: <PATH> computes SHA-256 of a Wasm binary \
          (simple app VK), --pubkey computes SHA-256 of a signing public key (versioned app VK)"
     );
-    let vk = match pubkey {
+    match pubkey {
         Some(pubkey_path) => {
             let pk_bytes = read_public_key(&pubkey_path)?;
-            B32(Sha256::digest(&pk_bytes).into())
+            Ok(B32(Sha256::digest(&pk_bytes).into()))
         }
-        None => {
-            let binary = match path {
-                Some(path) => fs::read(path)?,
-                None => {
-                    let bin_path = do_build()?;
-                    fs::read(bin_path)?
+        None => match path {
+            Some(path) => {
+                let binary = fs::read(path)?;
+                Ok(B32(Sha256::digest(&binary).into()))
+            }
+            None => {
+                let key_path = default_app_key_path();
+                if key_path.exists() {
+                    let secp = Secp256k1::new();
+                    let (_, vk) = load_keypair(&secp, &key_path)?;
+                    return Ok(vk);
                 }
-            };
-            B32(Sha256::digest(&binary).into())
-        }
-    };
+                let bin_path = do_build()?;
+                let binary = fs::read(bin_path)?;
+                Ok(B32(Sha256::digest(&binary).into()))
+            }
+        },
+    }
+}
 
-    println!("{}", vk);
+pub fn vk(path: Option<PathBuf>, pubkey: Option<PathBuf>) -> Result<()> {
+    println!("{}", resolve_app_vk(path, pubkey)?);
     Ok(())
 }
 
@@ -298,7 +307,9 @@ pub fn sign(key: PathBuf, bin: Option<PathBuf>, out: Option<PathBuf>) -> Result<
     let (vk, app_sig) = sign_wasm_at(&key, &wasm_path)?;
     match out {
         Some(p) => {
-            if p.extension().is_some_and(|ext| ext == "yaml" || ext == "yml") {
+            if p.extension()
+                .is_some_and(|ext| ext == "yaml" || ext == "yml")
+            {
                 write_signed_wasm(&p, vk, app_sig)?;
             } else {
                 let s = serde_json::to_string_pretty(&app_sig)?;
@@ -343,8 +354,7 @@ fn write_app_signatures(path: &Path, entries: &[(B32, AppSignature)]) -> Result<
     }
     let map: BTreeMap<B32, AppSignature> = entries.iter().cloned().collect();
     let s = serde_yaml::to_string(&map)?;
-    fs::write(path, s.as_bytes())
-        .with_context(|| format!("failed to write {}", path.display()))?;
+    fs::write(path, s.as_bytes()).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
 }
 
@@ -513,6 +523,26 @@ mod tests {
         maybe_auto_sign_with_key(&key_path, wasm_path.to_str().unwrap())?;
 
         assert!(!sig_path.exists());
+        remove_test_dir(&dir);
+        Ok(())
+    }
+
+    #[test]
+    fn vk_uses_app_key_when_no_path_or_pubkey() -> Result<()> {
+        use std::str::FromStr;
+
+        let dir = unique_test_dir("charms-vk-app-key");
+        fs::create_dir_all(dir.join(".charms"))?;
+        let key_path = dir.join(".charms/app-key.json");
+        keygen(Some(key_path.clone()))?;
+        let expected_vk = B32::from_str(&read_app_keypair(&key_path)?.vk)?;
+
+        let prev_cwd = std::env::current_dir()?;
+        std::env::set_current_dir(&dir)?;
+        let vk = resolve_app_vk(None, None)?;
+        std::env::set_current_dir(prev_cwd)?;
+
+        assert_eq!(vk, expected_vk);
         remove_test_dir(&dir);
         Ok(())
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -402,6 +402,20 @@ pub enum AppCommands {
         #[arg(long)]
         out: Option<PathBuf>,
     },
+
+    /// Verify a Wasm binary signature produced by `app sign`.
+    ///
+    /// Checks the BIP-340 Schnorr signature over the binary's SHA-256 hash.
+    /// By default reads `<wasm-path>.sig.yaml` (same as `app sign` / `app build` auto-signing).
+    Verify {
+        /// Path to the Wasm binary to verify (uses the release build output if omitted).
+        #[arg(long)]
+        bin: Option<PathBuf>,
+
+        /// Path to the signature file (default: `<wasm-path>.sig.yaml`).
+        #[arg(long)]
+        sig: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -479,6 +493,7 @@ pub async fn run() -> anyhow::Result<()> {
             AppCommands::Build => app::build(),
             AppCommands::Keygen { out } => app::keygen(out),
             AppCommands::Sign { key, bin, out } => app::sign(key, bin, out),
+            AppCommands::Verify { bin, sig } => app::verify(bin, sig),
         },
         Commands::Wallet { command } => {
             let wallet_cli = wallet_cli();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -355,9 +355,12 @@ pub enum AppCommands {
     ///
     /// For a simple (immutable) app the VK is SHA-256 of the Wasm binary.
     /// For a versioned app, pass `--pubkey` to compute SHA-256 of the signing public key.
+    /// When neither `<PATH>` nor `--pubkey` is given, uses the `vk` from `.charms/app-key.json`
+    /// if that file exists (from `app keygen`); otherwise builds the app and hashes the Wasm.
     /// Prints the hex-encoded VK to stdout.
     Vk {
-        /// Path to app Wasm binary (builds the app if omitted, ignored when --pubkey is set).
+        /// Path to app Wasm binary (ignored when `--pubkey` is set; otherwise builds the app
+        /// if omitted and `.charms/app-key.json` does not exist).
         path: Option<PathBuf>,
 
         /// Path to a BIP-340 x-only public key (secp256k1) in hex, or app keypair JSON.


### PR DESCRIPTION
## Summary

- **`charms app vk`**: when neither a Wasm path nor `--pubkey` is given, read the validated VK from `.charms/app-key.json` if it exists; otherwise fall back to building and hashing the Wasm binary.
- **`charms app verify`**: verify BIP-340 Schnorr signatures produced by `app sign`, defaulting to the release Wasm binary and `<wasm-path>.sig.yaml`.

## Test plan

- [x] `cargo test vk_uses_app_key_when_no_path_or_pubkey`
- [x] `cargo test verify_accepts_signature_from_sign`
- [x] `cargo test verify_rejects_tampered_binary`