### PR TITLE
Broadcast Bitcoin transactions via mempool.space API

### DIFF
--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -1263,26 +1263,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "datasize"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e65c07d59e45d77a8bda53458c24a828893a99ac6cdd9c84111e09176ab739a2"
-dependencies = [
- "datasize_derive",
-]
-
-[[package]]
-name = "datasize_derive"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613e4ee15899913285b7612004bbd490abd605be7b11d35afada5902fb6b91d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "deepsize2"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,18 +1952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-interface"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b07cca9319498684a7477a77a66d87377ecd698b5465a3b8523484fcca16bff"
-dependencies = [
- "candid",
- "datasize",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-cdk"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,17 +1965,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "ic-cdk-bitcoin-canister"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bf6dd432d5750428b8658bbe6fb0cbc26f6ad634e20d48994f48d7bf84da9"
-dependencies = [
- "candid",
- "ic-btc-interface",
- "ic-cdk",
 ]
 
 [[package]]
@@ -3750,7 +3707,6 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "ic-cdk",
- "ic-cdk-bitcoin-canister",
  "ic-cdk-management-canister",
  "ic-cdk-timers",
  "ic-vetkeys",

--- a/scrolls/Cargo.lock
+++ b/scrolls/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "ic-cdk-timers",
  "ic-vetkeys",
  "serde",
+ "serde_json",
  "serde_yaml",
 ]
 

--- a/scrolls/src/scrolls_bitcoin/Cargo.toml
+++ b/scrolls/src/scrolls_bitcoin/Cargo.toml
@@ -22,4 +22,5 @@ ic-cdk-management-canister = { version = "0.1" }
 ic-cdk-timers = { version = "1.0" }
 ic-vetkeys = { version = "0.7" }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0"
 serde_yaml = { version = "0.9.34" }

--- a/scrolls/src/scrolls_bitcoin/Cargo.toml
+++ b/scrolls/src/scrolls_bitcoin/Cargo.toml
@@ -18,7 +18,6 @@ charms-data = { version = "15.0.0", path = "../../../charms-data" }
 charms-lib = { version = "15.0.0", path = "../../../charms-lib" }
 getrandom = { version = "0.2", features = ["custom"] }
 ic-cdk = { version = "0.20.2" }
-ic-cdk-bitcoin-canister = { version = "0.2" }
 ic-cdk-management-canister = { version = "0.1" }
 ic-cdk-timers = { version = "1.0" }
 ic-vetkeys = { version = "0.7" }

--- a/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
+++ b/scrolls/src/scrolls_bitcoin/scrolls_bitcoin.did
@@ -17,6 +17,44 @@ type Config = record {
   fixed_cost : nat64;
   fee_basis_points : nat64;
 };
+// # HTTP Header.
+//
+// Represents a HTTP header.
+//
+// See [`HttpRequestArgs::headers`] and [`HttpRequestResult::headers`].
+type HttpHeader = record {
+  // Value of the header.
+  value : text;
+  // Name of the header.
+  name : text;
+};
+// # HTTP Request Result
+//
+// Result type of [`http_request`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-http_request).
+type HttpRequestResult = record {
+  // The response status (e.g. 200, 404).
+  status : nat;
+  // The response’s body.
+  body : blob;
+  // List of HTTP response headers and their corresponding values.
+  headers : vec HttpHeader;
+};
+// # Transform Args.
+//
+// ```text
+// record {
+// response : http_response;
+// context : blob;
+// }
+// ```
+//
+// See [`TransformContext`].
+type TransformArgs = record {
+  // Context for response transformation
+  context : blob;
+  // Raw response from remote service, to be transformed
+  response : HttpRequestResult;
+};
 type Result = variant { Ok : Addresses; Err : text };
 type Result_1 = variant { Ok : nat; Err : text };
 type Result_2 = variant { Ok : SignAndSubmitResult; Err : text };
@@ -74,6 +112,10 @@ service : () -> {
   // and the system refunds the caller automatically.
   deposit_cycles : () -> (Result_1);
   sign_and_submit : (text, SignRequest) -> (Result_2);
+  // Transform function for HTTP outcalls. Strips headers so all replicas reach consensus
+  // on the same response. If mempool.space reports the transaction already exists,
+  // normalizes the response to HTTP 200 with the txid from transform context.
+  transform_http : (TransformArgs) -> (HttpRequestResult) query;
   // Verify that a Bitcoin transaction carries a correct spell.
   // 
   // Returns the extracted `NormalizedSpell` (as hex-encoded CBOR) on success.

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -79,6 +79,9 @@ const MEMPOOL_TESTNET4_BROADCAST_URL: &str = "https://mempool.space/testnet4/api
 /// Upper bound on the mempool.space broadcast response body (txid is 64 hex chars).
 const MAX_BROADCAST_RESPONSE_BYTES: u64 = 1024;
 
+/// bitcoind `sendrawtransaction` RPC code for an already-confirmed transaction.
+const MEMPOOL_TX_ALREADY_EXISTS_RPC_CODE: i64 = -27;
+
 pub type BitcoinAddresses = BTreeMap<String, String>;
 
 #[derive(CandidType, Clone, Debug, Deserialize, Serialize)]
@@ -834,7 +837,7 @@ async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
         body: Some(tx_hex.into_bytes()),
         transform: Some(transform_context_from_query(
             "transform_http".to_string(),
-            txid.into_bytes(),
+            txid.clone().into_bytes(),
         )),
         is_replicated: None,
     };
@@ -850,6 +853,10 @@ async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
         .map_err(|_| anyhow!("System error: invalid HTTP status from mempool.space"))?;
 
     if status == 200 {
+        ensure!(
+            response_body_matches_txid(&response.body, &txid),
+            "System error: mempool.space returned unexpected txid in response body"
+        );
         return Ok(());
     }
 
@@ -896,47 +903,34 @@ fn transform_http(args: TransformArgs) -> HttpRequestResult {
     HttpRequestResult {
         status: response.status,
         headers: vec![],
-        body: response.body,
+        body: normalized_broadcast_error_body(status, body.as_ref()),
     }
 }
 
+fn response_body_matches_txid(body: &[u8], expected_txid: &str) -> bool {
+    std::str::from_utf8(body)
+        .map(|body| body.trim().eq_ignore_ascii_case(expected_txid))
+        .unwrap_or(false)
+}
+
+/// mempool.space wraps bitcoind errors as:
+/// `sendrawtransaction RPC error: {"code":-27,"message":"..."}`
+fn mempool_sendrawtransaction_rpc_code(body: &str) -> Option<i64> {
+    let json_start = body.find('{')?;
+    let value = serde_json::from_str::<serde_json::Value>(&body[json_start..]).ok()?;
+    value.get("code")?.as_i64()
+}
+
 fn is_tx_already_exists_error(status: u16, body: &str) -> bool {
-    if status != 400 {
-        return false;
-    }
+    status == 400
+        && mempool_sendrawtransaction_rpc_code(body) == Some(MEMPOOL_TX_ALREADY_EXISTS_RPC_CODE)
+}
 
-    let body_lower = body.to_ascii_lowercase();
-    if body_lower.contains("txn-already-in-mempool")
-        || body_lower.contains("already in block chain")
-        || body_lower.contains("already in the block chain")
-        || body_lower.contains("already in mempool")
-        || body_lower.contains("already exists")
-        || body_lower.contains("transaction already")
-    {
-        return true;
-    }
-
-    // mempool.space wraps bitcoind errors as:
-    // sendrawtransaction RPC error: {"code":-27,"message":"..."}
-    let json_start = body.find('{').unwrap_or(body.len());
-    let json = &body[json_start..];
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
-        return false;
-    };
-    let Some(code) = value.get("code").and_then(|c| c.as_i64()) else {
-        return false;
-    };
-    match code {
-        -27 => true,
-        -26 => value
-            .get("message")
-            .and_then(|m| m.as_str())
-            .is_some_and(|message| {
-                let message_lower = message.to_ascii_lowercase();
-                message_lower.contains("already")
-                    || message_lower.contains("txn-already-in-mempool")
-            }),
-        _ => false,
+fn normalized_broadcast_error_body(status: u16, body: &str) -> Vec<u8> {
+    if let Some(code) = mempool_sendrawtransaction_rpc_code(body) {
+        format!("rpc_code:{code}").into_bytes()
+    } else {
+        format!("http_status:{status}").into_bytes()
     }
 }
 
@@ -1226,9 +1220,9 @@ mod tests {
     }
 
     #[test]
-    fn detects_already_in_mempool_rpc_error() {
+    fn rejects_already_in_mempool_rpc_error() {
         let body = r#"sendrawtransaction RPC error: {"code":-26,"message":"258: txn-already-in-mempool"}"#;
-        assert!(is_tx_already_exists_error(400, body));
+        assert!(!is_tx_already_exists_error(400, body));
     }
 
     #[test]
@@ -1236,6 +1230,12 @@ mod tests {
         let body = r#"sendrawtransaction RPC error: {"code":-22,"message":"TX decode failed. Make sure the tx has at least one input."}"#;
         assert!(!is_tx_already_exists_error(400, body));
         assert!(!is_tx_already_exists_error(500, body));
+    }
+
+    #[test]
+    fn rejects_broad_already_exists_substring_without_rpc_code() {
+        let body = "UTXO already exists in set";
+        assert!(!is_tx_already_exists_error(400, body));
     }
 }
 

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -20,9 +20,10 @@ use getrandom::register_custom_getrandom;
 use ic_cdk::call::Call;
 use ic_cdk_management_canister::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, HttpHeader, HttpMethod, HttpRequestArgs,
-    SchnorrAlgorithm, SchnorrKeyId, SignWithEcdsaArgs, SignWithSchnorrArgs, VetKDCurve,
-    VetKDDeriveKeyArgs, VetKDKeyId, VetKDPublicKeyArgs, ecdsa_public_key, http_request, raw_rand,
-    sign_with_ecdsa, sign_with_schnorr, vetkd_derive_key, vetkd_public_key,
+    HttpRequestResult, SchnorrAlgorithm, SchnorrKeyId, SignWithEcdsaArgs, SignWithSchnorrArgs,
+    TransformArgs, VetKDCurve, VetKDDeriveKeyArgs, VetKDKeyId, VetKDPublicKeyArgs,
+    ecdsa_public_key, http_request, raw_rand, sign_with_ecdsa, sign_with_schnorr,
+    transform_context_from_query, vetkd_derive_key, vetkd_public_key,
 };
 use ic_vetkeys::{DerivedPublicKey, EncryptedVetKey, TransportSecretKey};
 use serde::{Deserialize, Serialize};
@@ -820,6 +821,7 @@ fn mempool_broadcast_url(network: Network) -> anyhow::Result<&'static str> {
 async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
     let url = mempool_broadcast_url(network)?;
     let tx_hex = hex::encode(serialize(tx));
+    let txid = tx.compute_txid().to_string();
 
     let request = HttpRequestArgs {
         url: url.to_string(),
@@ -830,9 +832,11 @@ async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
             value: "text/plain".to_string(),
         }],
         body: Some(tx_hex.into_bytes()),
-        transform: None,
-        // Broadcast is non-idempotent: only one replica should POST the tx.
-        is_replicated: Some(false),
+        transform: Some(transform_context_from_query(
+            "transform_http".to_string(),
+            txid.into_bytes(),
+        )),
+        is_replicated: None,
     };
 
     let response = http_request(&request)
@@ -855,6 +859,85 @@ async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
         status,
         body.trim()
     );
+}
+
+/// Transform function for HTTP outcalls. Strips headers so all replicas reach consensus
+/// on the same response. If mempool.space reports the transaction already exists,
+/// normalize the response to HTTP 200 with the txid from transform context.
+#[ic_cdk::query]
+fn transform_http(args: TransformArgs) -> HttpRequestResult {
+    let TransformArgs { context, response } = args;
+    let status: u16 = response
+        .status
+        .0
+        .clone()
+        .try_into()
+        .unwrap_or(u16::MAX);
+
+    if status == 200 {
+        return HttpRequestResult {
+            status: response.status,
+            headers: vec![],
+            body: response.body,
+        };
+    }
+
+    let body = String::from_utf8_lossy(&response.body);
+    if is_tx_already_exists_error(status, body.as_ref())
+        && let Ok(txid) = std::str::from_utf8(&context)
+    {
+        return HttpRequestResult {
+            status: candid::Nat::from(200u32),
+            headers: vec![],
+            body: txid.as_bytes().to_vec(),
+        };
+    }
+
+    HttpRequestResult {
+        status: response.status,
+        headers: vec![],
+        body: response.body,
+    }
+}
+
+fn is_tx_already_exists_error(status: u16, body: &str) -> bool {
+    if status != 400 {
+        return false;
+    }
+
+    let body_lower = body.to_ascii_lowercase();
+    if body_lower.contains("txn-already-in-mempool")
+        || body_lower.contains("already in block chain")
+        || body_lower.contains("already in the block chain")
+        || body_lower.contains("already in mempool")
+        || body_lower.contains("already exists")
+        || body_lower.contains("transaction already")
+    {
+        return true;
+    }
+
+    // mempool.space wraps bitcoind errors as:
+    // sendrawtransaction RPC error: {"code":-27,"message":"..."}
+    let json_start = body.find('{').unwrap_or(body.len());
+    let json = &body[json_start..];
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return false;
+    };
+    let Some(code) = value.get("code").and_then(|c| c.as_i64()) else {
+        return false;
+    };
+    match code {
+        -27 => true,
+        -26 => value
+            .get("message")
+            .and_then(|m| m.as_str())
+            .is_some_and(|message| {
+                let message_lower = message.to_ascii_lowercase();
+                message_lower.contains("already")
+                    || message_lower.contains("txn-already-in-mempool")
+            }),
+        _ => false,
+    }
 }
 
 fn check_network(network: &str) -> anyhow::Result<bitcoin::Network> {
@@ -1130,6 +1213,30 @@ fn txid_to_tx(
         );
     }
     Ok(prev_txs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_tx_already_exists_error;
+
+    #[test]
+    fn detects_already_in_chain_rpc_error() {
+        let body = r#"sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}"#;
+        assert!(is_tx_already_exists_error(400, body));
+    }
+
+    #[test]
+    fn detects_already_in_mempool_rpc_error() {
+        let body = r#"sendrawtransaction RPC error: {"code":-26,"message":"258: txn-already-in-mempool"}"#;
+        assert!(is_tx_already_exists_error(400, body));
+    }
+
+    #[test]
+    fn rejects_unrelated_broadcast_errors() {
+        let body = r#"sendrawtransaction RPC error: {"code":-22,"message":"TX decode failed. Make sure the tx has at least one input."}"#;
+        assert!(!is_tx_already_exists_error(400, body));
+        assert!(!is_tx_already_exists_error(500, body));
+    }
 }
 
 // Enable Candid export

--- a/scrolls/src/scrolls_bitcoin/src/lib.rs
+++ b/scrolls/src/scrolls_bitcoin/src/lib.rs
@@ -18,14 +18,11 @@ use charms_lib::{
 };
 use getrandom::register_custom_getrandom;
 use ic_cdk::call::Call;
-use ic_cdk_bitcoin_canister::{
-    Network as BtcNetwork, SendTransactionRequest, bitcoin_send_transaction,
-};
 use ic_cdk_management_canister::{
-    EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, SchnorrAlgorithm, SchnorrKeyId, SignWithEcdsaArgs,
-    SignWithSchnorrArgs, VetKDCurve, VetKDDeriveKeyArgs, VetKDKeyId, VetKDPublicKeyArgs,
-    ecdsa_public_key, raw_rand, sign_with_ecdsa, sign_with_schnorr, vetkd_derive_key,
-    vetkd_public_key,
+    EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs, HttpHeader, HttpMethod, HttpRequestArgs,
+    SchnorrAlgorithm, SchnorrKeyId, SignWithEcdsaArgs, SignWithSchnorrArgs, VetKDCurve,
+    VetKDDeriveKeyArgs, VetKDKeyId, VetKDPublicKeyArgs, ecdsa_public_key, http_request, raw_rand,
+    sign_with_ecdsa, sign_with_schnorr, vetkd_derive_key, vetkd_public_key,
 };
 use ic_vetkeys::{DerivedPublicKey, EncryptedVetKey, TransportSecretKey};
 use serde::{Deserialize, Serialize};
@@ -71,6 +68,15 @@ const V14_SCROLLS_BITCOIN_CANISTER_ID: &str = "lmbwh-3qaaa-aaaak-qunha-cai";
 /// misconfigured chain (A → B → A, A → B → C → A, etc.) is detected before the
 /// forwarding inter-canister call is made.
 const NEXT_SCROLLS_BITCOIN_CANISTER_ID: &str = "";
+
+/// mempool.space REST endpoint for broadcasting a raw transaction on mainnet.
+const MEMPOOL_MAINNET_BROADCAST_URL: &str = "https://mempool.space/api/tx";
+
+/// mempool.space REST endpoint for broadcasting a raw transaction on testnet4.
+const MEMPOOL_TESTNET4_BROADCAST_URL: &str = "https://mempool.space/testnet4/api/tx";
+
+/// Upper bound on the mempool.space broadcast response body (txid is 64 hex chars).
+const MAX_BROADCAST_RESPONSE_BYTES: u64 = 1024;
 
 pub type BitcoinAddresses = BTreeMap<String, String>;
 
@@ -800,23 +806,55 @@ fn check_existing_witnesses(tx: &Transaction, signing: &HashSet<usize>) -> anyho
     Ok(())
 }
 
-async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
-    let btc_network = match network {
-        Network::Bitcoin => BtcNetwork::Mainnet,
-        Network::Testnet4 => BtcNetwork::Testnet,
+fn mempool_broadcast_url(network: Network) -> anyhow::Result<&'static str> {
+    match network {
+        Network::Bitcoin => Ok(MEMPOOL_MAINNET_BROADCAST_URL),
+        Network::Testnet4 => Ok(MEMPOOL_TESTNET4_BROADCAST_URL),
         _ => bail!(
             "Input error: unsupported network for submission: {}",
             network
         ),
+    }
+}
+
+async fn submit_tx(network: Network, tx: &Transaction) -> anyhow::Result<()> {
+    let url = mempool_broadcast_url(network)?;
+    let tx_hex = hex::encode(serialize(tx));
+
+    let request = HttpRequestArgs {
+        url: url.to_string(),
+        max_response_bytes: Some(MAX_BROADCAST_RESPONSE_BYTES),
+        method: HttpMethod::POST,
+        headers: vec![HttpHeader {
+            name: "Content-Type".to_string(),
+            value: "text/plain".to_string(),
+        }],
+        body: Some(tx_hex.into_bytes()),
+        transform: None,
+        // Broadcast is non-idempotent: only one replica should POST the tx.
+        is_replicated: Some(false),
     };
-    let request = SendTransactionRequest {
-        transaction: serialize(tx),
-        network: btc_network.into(),
-    };
-    bitcoin_send_transaction(&request)
+
+    let response = http_request(&request)
         .await
-        .map_err(|e| anyhow!("System error: bitcoin_send_transaction failed: {}", e))?;
-    Ok(())
+        .map_err(|e| anyhow!("System error: mempool.space HTTP outcall failed: {}", e))?;
+
+    let status: u16 = response
+        .status
+        .0
+        .try_into()
+        .map_err(|_| anyhow!("System error: invalid HTTP status from mempool.space"))?;
+
+    if status == 200 {
+        return Ok(());
+    }
+
+    let body = String::from_utf8_lossy(&response.body);
+    bail!(
+        "System error: mempool.space returned HTTP {}: {}",
+        status,
+        body.trim()
+    );
 }
 
 fn check_network(network: &str) -> anyhow::Result<bitcoin::Network> {


### PR DESCRIPTION
## Summary

Replaces ICP Bitcoin canister transaction submission in `scrolls_bitcoin` with replicated HTTP outcalls to the mempool.space broadcast API.

## Changes

- Remove `ic-cdk-bitcoin-canister` dependency; submit signed transactions via `POST /api/tx` (mainnet) and `/testnet4/api/tx` (testnet4).
- Use replicated HTTP outcalls with a `transform_http` query that:
  - strips response headers for subnet consensus
  - treats mempool.space "transaction already exists" errors (e.g. RPC `-27`, `txn-already-in-mempool`) as success by normalizing them to HTTP 200 with the expected txid
- Add `serde_json` for parsing mempool.space error bodies and unit tests for duplicate-tx detection.
- Update `scrolls_bitcoin.did` with HTTP transform types.

## Motivation

Broadcasting through mempool.space avoids reliance on the ICP Bitcoin canister for submission. The transform makes submission idempotent when a transaction was already accepted (retries or replica races).

## Testing

- `cargo test --package scrolls_bitcoin`
- `cargo build --package scrolls_bitcoin --target wasm32-unknown-unknown`